### PR TITLE
Healthcheck endpoint per session/channel

### DIFF
--- a/server.js
+++ b/server.js
@@ -29,18 +29,22 @@ class RefAssetManager {
   getNextVod(vodRequest) {
     return new Promise((resolve, reject) => {
       const channelId = vodRequest.playlistId;
-      let vod = this.assets[channelId][this.pos[channelId]++];
-      if (this.pos[channelId] > this.assets[channelId].length - 1) {
-        this.pos[channelId] = 0;
+      if (this.pos[channelId]) {
+        let vod = this.assets[channelId][this.pos[channelId]++];
+        if (this.pos[channelId] > this.assets[channelId].length - 1) {
+          this.pos[channelId] = 0;
+        }
+        resolve(vod);  
+      } else {
+        reject("Invalid channelId provided");
       }
-      resolve(vod);
     });
   }
 };
 
 class RefChannelManager {
   getChannels() {
-    return [ { id: '1', profile: this._getProfile() } ];
+    return [ { id: '1', profile: this._getProfile() }, { id: '2', profile: this._getProfile() } ];
   }
 
   _getProfile() {


### PR DESCRIPTION
This PR provides a health check endpoint per channel (or session) that responds with 200 OK or 503 if playhead is either idle or failing.