### PR TITLE
Master manifest filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ $ npm start
 
 Then point your HLS video player to `http://localhost:8000/live/master.m3u8?channel=1` to start playing the linear live stream.
 
+## Master manifest filtering
+
+The engine supports a very simplistic and basic filtering of media playlists included in the master manifest. Currently supports to filter on video bandwidth and video height. To specify a filter provide the query parameter `filter` when loading the master manifest, e.g. `(type=="video"&&height>200)&&(type=="video"&&height<400)`. This needs to be URL encoded resulting in the following URL: `http://localhost:8000/live/master.m3u8?channel=1&filter=%28type%3D%3D%22video%22%26%26height%3E200%29%26%26%28type%3D%3D%22video%22%26%26height%3C400%29`
+
 ## API
 
 Initiate and start the engine as below.

--- a/engine/server.js
+++ b/engine/server.js
@@ -7,6 +7,7 @@ const EventStream = require('./event_stream.js');
 
 const { SessionStateStore } = require('./session_state.js');
 const { PlayheadStateStore } = require('./playhead_state.js');
+const { filterQueryParser } = require('./util.js');
 
 const sessions = {}; // Should be a persistent store...
 const eventStreams = {};
@@ -188,8 +189,14 @@ class ChannelEngine {
       const eventStream = new EventStream(session);
       eventStreams[session.sessionId] = eventStream;
 
+      let filter;
+      if (req.query['filter']) {
+        debug(`Applying filter on master manifest ${req.query['filter']}`);
+        filter = filterQueryParser(req.query['filter']);
+      }
+
       try {
-        const body = await session.getMasterManifestAsync();
+        const body = await session.getMasterManifestAsync(filter);
         res.sendRaw(200, body, { 
           "Content-Type": "application/x-mpegURL",
           "Access-Control-Allow-Origin": "*",

--- a/engine/session.js
+++ b/engine/session.js
@@ -8,6 +8,8 @@ const Readable = require('stream').Readable;
 const { SessionState } = require('./session_state.js');
 const { PlayheadState } = require('./playhead_state.js');
 
+const { applyFilter } = require('./util.js');
+
 const AVERAGE_SEGMENT_DURATION = 3000;
 
 const timer = ms => new Promise(res => setTimeout(res, ms));
@@ -295,7 +297,7 @@ class Session {
     return m3u8;
   }
 
-  async getMasterManifestAsync() {
+  async getMasterManifestAsync(filter) {
     await this._tickAsync();
     let m3u8 = "#EXTM3U\n";
     m3u8 += "#EXT-X-VERSION:4\n";
@@ -316,7 +318,8 @@ class Session {
       }
     }
     if (this._sessionProfile) {
-      this._sessionProfile.forEach(profile => {
+      const sessionProfile = filter ? applyFilter(this._sessionProfile, filter) : this._sessionProfile;
+      sessionProfile.forEach(profile => {
         m3u8 += '#EXT-X-STREAM-INF:BANDWIDTH=' + profile.bw + ',RESOLUTION=' + profile.resolution[0] + 'x' + profile.resolution[1] + ',CODECS="' + profile.codecs + '"' + (defaultAudioGroupId ? `,AUDIO="${defaultAudioGroupId}"` : '') + '\n';
         m3u8 += "master" + profile.bw + ".m3u8;session=" + this._sessionId + "\n";
       });

--- a/engine/util.js
+++ b/engine/util.js
@@ -1,0 +1,34 @@
+const filterQueryParser = (filterQuery) => {
+  const conditions = filterQuery.match(/\(([^\(\)]*?)\)/g);
+
+  let filter = {};
+  conditions.map((c) => {
+    const m = c.match(/\(type=="(.*?)"(&&|\|\|)(.*?)(<|>)(.*)\)/);
+    if (m) {
+      const type = m[1];
+      const operator = m[2];
+      const key = m[3];
+      const comp = m[4];
+      const value = m[5];
+      
+      if (!filter[type]) {
+        filter[type] = {};
+      }
+      if (operator === "&&") {
+        if (!filter[type][key]) {
+          filter[type][key] = {};
+        }
+        if (comp === "<") {
+          filter[type][key].high = parseInt(value, 10); 
+        } else if (comp === ">") {
+          filter[type][key].low = parseInt(value, 10); 
+        }
+      }
+    }
+  });
+  return filter;
+};
+
+module.exports = {
+  filterQueryParser
+}

--- a/engine/util.js
+++ b/engine/util.js
@@ -29,6 +29,20 @@ const filterQueryParser = (filterQuery) => {
   return filter;
 };
 
+const applyFilter = (profiles, filter) => {
+  return profiles.filter(profile => {
+    if (filter.video && filter.video.systemBitrate) {
+      return (profile.bw >= filter.video.systemBitrate.low && 
+        profile.bw <= filter.video.systemBitrate.high);
+    } else if (filter.video && filter.video.height) {
+      return (profile.resolution[1] >= filter.video.height.low &&
+        profile.resolution[1] <= filter.video.height.high);
+    }
+    return true;
+  });
+};
+
 module.exports = {
-  filterQueryParser
+  filterQueryParser,
+  applyFilter
 }

--- a/spec/engine/util_spec.js
+++ b/spec/engine/util_spec.js
@@ -1,0 +1,11 @@
+const { filterQueryParser } = require('../../engine/util.js');
+
+fdescribe("Filter Query parser", () => {
+  it("can handle systemBitrate low/high range", () => {
+    const filterQuery = `(type=="video"&&systemBitrate>100000)&&(type=="video"&&systemBitrate<800000)`;
+    const filter = filterQueryParser(filterQuery);
+  
+    expect(filter.video.systemBitrate.low).toEqual(100000);
+    expect(filter.video.systemBitrate.high).toEqual(800000);  
+  });
+});

--- a/spec/engine/util_spec.js
+++ b/spec/engine/util_spec.js
@@ -1,11 +1,69 @@
-const { filterQueryParser } = require('../../engine/util.js');
+const { filterQueryParser, applyFilter } = require('../../engine/util.js');
 
-fdescribe("Filter Query parser", () => {
+describe("Filter Query parser", () => {
   it("can handle systemBitrate low/high range", () => {
     const filterQuery = `(type=="video"&&systemBitrate>100000)&&(type=="video"&&systemBitrate<800000)`;
     const filter = filterQueryParser(filterQuery);
   
     expect(filter.video.systemBitrate.low).toEqual(100000);
     expect(filter.video.systemBitrate.high).toEqual(800000);  
+  });
+
+  it("can handle resolution low/high range", () => {
+    const filterQuery = `(type=="video"&&height>600)&&(type=="video"&&height<1080)`;
+    const filter = filterQueryParser(filterQuery);
+
+    expect(filter.video.height.low).toEqual(600);
+    expect(filter.video.height.high).toEqual(1080);  
+  });
+});
+
+describe("Profile filter", () => {
+  let PROFILE;
+
+  beforeEach(() => {
+    PROFILE = [
+      {
+        bw: 6134000,
+        codecs: 'avc1.4d001f,mp4a.40.2',
+        resolution: [ 1024, 458 ]
+      },
+      {
+        bw: 2323000,
+        codecs: 'avc1.4d001f,mp4a.40.2',
+        resolution: [ 640, 286 ]
+      },
+      {
+        bw: 1313000,
+        codecs: 'avc1.4d001f,mp4a.40.2',
+        resolution: [ 480, 214 ]
+      }
+    ],
+    [
+      {
+        bw: 6134000,
+        codecs: 'avc1.4d001f,mp4a.40.2',
+        resolution: [ 1024, 458 ]
+      },
+      {
+        bw: 2323000,
+        codecs: 'avc1.4d001f,mp4a.40.2',
+        resolution: [ 640, 286 ]
+      },
+      {
+        bw: 1313000,
+        codecs: 'avc1.4d001f,mp4a.40.2',
+        resolution: [ 480, 214 ]
+      }
+    ];
+  });
+
+  
+  it ("can filter out video tracks with height min 200 and max 400", () => {
+    const filterQuery = `(type=="video"&&height>200)&&(type=="video"&&height<400)`;
+    const filter = filterQueryParser(filterQuery);
+
+    const filteredProfiles = applyFilter(PROFILE, filter);
+    expect(filteredProfiles.length).toEqual(2);
   });
 });


### PR DESCRIPTION
This PR adds support for a very simplistic and basic filtering of media playlists included in the master manifest. Currently supports to filter on video bandwidth and video height. To specify a filter provide the query parameter `filter` when loading the master manifest, e.g. `(type=="video"&&height>200)&&(type=="video"&&height<400)`. This needs to be URL encoded resulting in the following URL: `http://localhost:8000/live/master.m3u8?channel=1&filter=%28type%3D%3D%22video%22%26%26height%3E200%29%26%26%28type%3D%3D%22video%22%26%26height%3C400%29`