### PR TITLE
fix: shared store was initiated on startup

### DIFF
--- a/engine/memcached_state_store.js
+++ b/engine/memcached_state_store.js
@@ -8,10 +8,20 @@ class MemcachedStateStore {
   }
 
   async initAsync(id, initData) {
+    const isInitiated = await this.getAsync(id, "_initiated");
     let data = {};
-    for(const key of Object.keys(initData)) {
-      debug(`${this.keyPrefix} Initiating key ${key} with init data`);
-      data[key] = await this.setAsync(id, key, initData[key]);
+    if (!isInitiated) {
+      for(const key of Object.keys(initData)) {
+        debug(`${this.keyPrefix} Initiating key ${key} with init data`);
+        data[key] = await this.setAsync(id, key, initData[key]);
+      }
+      await this.setAsync(id, "_initiated", true);
+    } else {
+      debug(`${this.keyPrefix} Already initiated, not initiating with init data`);
+      for(const key of Object.keys(initData)) {
+        debug(`${this.keyPrefix} Initiating key ${key} with data from store`);
+        data[key] = await this.getAsync(id, key);
+      }
     }
     return data;
   }

--- a/engine/redis_state_store.js
+++ b/engine/redis_state_store.js
@@ -8,10 +8,20 @@ class RedisStateStore {
   }
 
   async initAsync(id, initData) {
+    const isInitiated = await this.getAsync(id, "_initiated");
     let data = {};
-    for(const key of Object.keys(initData)) {
-      debug(`${this.keyPrefix} Initiating key ${key} with init data`);
-      data[key] = await this.setAsync(id, key, initData[key]);
+    if (!isInitiated) {
+      for(const key of Object.keys(initData)) {
+        debug(`${this.keyPrefix} Initiating key ${key} with init data`);
+        data[key] = await this.setAsync(id, key, initData[key]);
+      }
+      await this.setAsync(id, "_initiated", true);
+    } else {
+      debug(`${this.keyPrefix} Already initiated, not initiating with init data`);
+      for(const key of Object.keys(initData)) {
+        debug(`${this.keyPrefix} Initiating key ${key} with data from store`);
+        data[key] = await this.getAsync(id, key);
+      }
     }
     return data;
   }

--- a/engine/session_state.js
+++ b/engine/session_state.js
@@ -48,6 +48,7 @@ class SharedSessionState {
       }
     }
     this.cache.currentVod.ts = Date.now();
+    this.cache.currentVod.value = hlsVod;
     return hlsVod;
   }
 
@@ -73,7 +74,9 @@ class SharedSessionState {
   }
 
   async getValues(keys) {
-    return await this.store.getValues(this.sessionId, keys);
+    const values = await this.store.getValues(this.sessionId, keys);
+    //debug(values);
+    return values;
   }
 
   async set(key, value) {


### PR DESCRIPTION
This PR resolves the bug where a second instance of the engine would wipe the shared store with init data on startup