### PR TITLE
Generate instance id and include in header responses

### DIFF
--- a/engine/memcached_state_store.js
+++ b/engine/memcached_state_store.js
@@ -4,6 +4,11 @@ const debug = require("debug")("memcached-state-store");
 class MemcachedStateStore {
   constructor(keyPrefix, opts) {
     this.keyPrefix = keyPrefix;
+    if (opts.version) {
+      const prependPrefix = opts.version.replace(/\./g, "X");
+      this.keyPrefix = prependPrefix + this.keyPrefix;
+      debug(`Prepending keyprefix with ${prependPrefix} => ${this.keyPrefix}`);
+    }
     this.client = new MemcacheClient({ server: opts.memcachedUrl, cmdTimeout: 10000 });
   }
 
@@ -12,14 +17,14 @@ class MemcachedStateStore {
     let data = {};
     if (!isInitiated) {
       for(const key of Object.keys(initData)) {
-        debug(`${this.keyPrefix} Initiating key ${key} with init data`);
+        debug(`${this.keyPrefix}:${id}: Initiating key ${key} with init data`);
         data[key] = await this.setAsync(id, key, initData[key]);
       }
       await this.setAsync(id, "_initiated", true);
     } else {
-      debug(`${this.keyPrefix} Already initiated, not initiating with init data`);
+      debug(`${this.keyPrefix}:${id}: Already initiated, not initiating with init data`);
       for(const key of Object.keys(initData)) {
-        debug(`${this.keyPrefix} Initiating key ${key} with data from store`);
+        debug(`${this.keyPrefix}:${id}: Initiating key ${key} with data from store`);
         data[key] = await this.getAsync(id, key);
       }
     }

--- a/engine/redis_state_store.js
+++ b/engine/redis_state_store.js
@@ -4,6 +4,11 @@ const debug = require("debug")("redis-state-store");
 class RedisStateStore {
   constructor(keyPrefix, opts) {
     this.keyPrefix = keyPrefix;
+    if (opts.version) {
+      const prependPrefix = opts.version.replace(/\./g, "X");
+      this.keyPrefix = prependPrefix + this.keyPrefix;
+      debug(`Prepending keyprefix with ${prependPrefix} => ${this.keyPrefix}`);
+    }
     this.client = redis.createClient(opts.redisUrl);
   }
 
@@ -12,14 +17,14 @@ class RedisStateStore {
     let data = {};
     if (!isInitiated) {
       for(const key of Object.keys(initData)) {
-        debug(`${this.keyPrefix} Initiating key ${key} with init data`);
+        debug(`${this.keyPrefix}:${id}: Initiating key ${key} with init data`);
         data[key] = await this.setAsync(id, key, initData[key]);
       }
       await this.setAsync(id, "_initiated", true);
     } else {
-      debug(`${this.keyPrefix} Already initiated, not initiating with init data`);
+      debug(`${this.keyPrefix}:${id}: Already initiated, not initiating with init data`);
       for(const key of Object.keys(initData)) {
-        debug(`${this.keyPrefix} Initiating key ${key} with data from store`);
+        debug(`${this.keyPrefix}:${id}: Initiating key ${key} with data from store`);
         data[key] = await this.getAsync(id, key);
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -844,6 +844,13 @@
         "tough-cookie": "~2.5.0",
         "tunnel-agent": "^0.6.0",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
       }
     },
     "restify": {
@@ -879,6 +886,11 @@
           "version": "6.9.3",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.3.tgz",
           "integrity": "sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -1116,9 +1128,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "vasync": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "memcache-client": "^0.10.1",
     "redis": "^3.0.2",
     "request": ">=2.88.0",
-    "restify": ">=8.5.1"
+    "restify": ">=8.5.1",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "jasmine": "^3.1.0"


### PR DESCRIPTION
Add `X-Instance-Id` header in responses to identify server instance. This is useful when debugging HA setups.