### PR TITLE
High-avail fix: Media sequence incremented by multiple nodes

### DIFF
--- a/engine/memcached_state_store.js
+++ b/engine/memcached_state_store.js
@@ -51,6 +51,10 @@ class MemcachedStateStore {
     return value;
   }
 
+  async setVolatileAsync(id, key, value) {
+    throw new Error("memcached: setVolatileAsync not implemented yet");
+  }
+
   async removeAsync(id, key) {
     throw new Error("memcached: removeAsync not implemented yet");
   }  

--- a/engine/memcached_state_store.js
+++ b/engine/memcached_state_store.js
@@ -50,6 +50,10 @@ class MemcachedStateStore {
     await this.client.set(storeKey, JSON.stringify(value));
     return value;
   }
+
+  async removeAsync(id, key) {
+    throw new Error("memcached: removeAsync not implemented yet");
+  }  
 }
 
 module.exports = MemcachedStateStore;

--- a/engine/memory_state_store.js
+++ b/engine/memory_state_store.js
@@ -26,6 +26,10 @@ class MemoryStateStore {
     return this.sharedStates[id][key];
   }
 
+  async setVolatileAsync(id, key, value) {
+    return await this.setAsync(id, key, value);
+  }
+
   async removeAsync(id, key) {
     delete this.sharedStates[id][key];
   }  

--- a/engine/memory_state_store.js
+++ b/engine/memory_state_store.js
@@ -25,6 +25,10 @@ class MemoryStateStore {
     this.sharedStates[id][key] = value;
     return this.sharedStates[id][key];
   }
+
+  async removeAsync(id, key) {
+    delete this.sharedStates[id][key];
+  }  
 }
 
 module.exports = MemoryStateStore;

--- a/engine/redis_state_store.js
+++ b/engine/redis_state_store.js
@@ -67,6 +67,22 @@ class RedisStateStore {
     return await setAsync;
   }
 
+  async setVolatileAsync(id, key, value) {
+    const data = await this.setAsync(id, key, value);
+    const storeKey = "" + this.keyPrefix + id + key;
+    const expireAsync = new Promise((resolve, reject) => {
+      this.client.expire(storeKey, 5, (err, res) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+    });
+    await expireAsync;
+    return data;
+  }
+
   async removeAsync(id, key) {
     const storeKey = "" + this.keyPrefix + id + key;
     const delAsync = new Promise((resolve, reject) => {

--- a/engine/redis_state_store.js
+++ b/engine/redis_state_store.js
@@ -65,7 +65,21 @@ class RedisStateStore {
       });
     });
     return await setAsync;
-  }  
+  }
+
+  async removeAsync(id, key) {
+    const storeKey = "" + this.keyPrefix + id + key;
+    const delAsync = new Promise((resolve, reject) => {
+      this.client.del(storeKey, (err, res) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+    });
+    await delAsync;
+  }
 }
 
 module.exports = RedisStateStore;

--- a/engine/server.js
+++ b/engine/server.js
@@ -50,7 +50,8 @@ class ChannelEngine {
         redisUrl: options.redisUrl, 
         memcachedUrl: options.memcachedUrl, 
         cacheTTL: options.sharedStoreCacheTTL,
-        version: version })
+        version: version }),
+      instanceId: this.instanceId,
     };
 
     if (options && options.staticDirectory) {

--- a/engine/session.js
+++ b/engine/session.js
@@ -477,7 +477,7 @@ class Session {
     let newVod;
 
     let sessionState = await this._sessionState.getValues( 
-      ["state", "assetId", "vodMediaSeqVideo", "vodMediaSeqAudio", "mediaSeq", "discSeq"]);
+      ["state", "assetId", "vodMediaSeqVideo", "vodMediaSeqAudio", "mediaSeq", "discSeq", "nextVod"]);
 
     let currentVod = await this._sessionState.getCurrentVod();
     let vodResponse;
@@ -489,13 +489,14 @@ class Session {
           let nextVodPromise;
           if (sessionState.state === SessionState.VOD_INIT) {
             debug(`[${this._sessionId}]: state=VOD_INIT`);
-            nextVodPromise = this._getNextVod();
+            nextVodPromise = this._getNextVod(sessionState);
           } else if (sessionState.state === SessionState.VOD_INIT_BY_ID) {
             debug(`[${this._sessionId}]: state=VOD_INIT_BY_ID ${sessionState.assetId}`);
             nextVodPromise = this._getNextVodById(sessionState.assetId);
           }
           const nextVodStart = Date.now();
           vodResponse = await nextVodPromise;
+          sessionState.nextVod = await this._sessionState.set("nextVod", vodResponse);
           cloudWatchLog(!this.cloudWatchLogging, 'engine-session',
             { event: 'nextVod', channel: this._sessionId, reqTimeMs: Date.now() - nextVodStart });
           let loadPromise;
@@ -540,6 +541,7 @@ class Session {
           });
           sessionState.state = await this._sessionState.set("state", SessionState.VOD_PLAYING);
           sessionState.currentVod = await this._sessionState.setCurrentVod(currentVod);
+          await this._sessionState.remove("nextVod");
           return;
         } catch (err) {
           console.error(`[${this._sessionId}]: Failed to init first VOD`);
@@ -570,7 +572,7 @@ class Session {
           const length = currentVod.getLiveMediaSequencesCount();
           const lastDiscontinuity = currentVod.getLastDiscontinuity();
           sessionState.state = await this._sessionState.set("state", SessionState.VOD_NEXT_INITIATING);
-          let vodPromise = this._getNextVod();
+          let vodPromise = this._getNextVod(sessionState);
           if (length === 1) {
             // Add a grace period for very short VODs before calling nextVod
             const gracePeriod = (this.averageSegmentDuration / 2);
@@ -579,6 +581,7 @@ class Session {
           }
           const nextVodStart = Date.now();
           vodResponse = await vodPromise;
+          sessionState.nextVod = await this._sessionState.set("nextVod", vodResponse);
           cloudWatchLog(!this.cloudWatchLogging, 'engine-session',
             { event: 'nextVod', channel: this._sessionId, reqTimeMs: Date.now() - nextVodStart });
           let loadPromise;
@@ -623,6 +626,7 @@ class Session {
           sessionState.vodMediaSeqAudio = await this._sessionState.set("vodMediaSeqAudio", 0);
           sessionState.mediaSeq = await this._sessionState.set("mediaSeq", sessionState.mediaSeq + length);
           sessionState.discSeq = await this._sessionState.set("discSeq", sessionState.discSeq + lastDiscontinuity);
+          await this._sessionState.remove("nextVod");
           sessionState.currentVod = await this._sessionState.setCurrentVod(currentVod);
           await this._playheadState.set("playheadRef", Date.now());
           this.produceEvent({
@@ -653,14 +657,24 @@ class Session {
     }
   }
 
-  _getNextVod() {
+  _getNextVod(sessionState) {
     return new Promise((resolve, reject) => {
-      this._assetManager.getNextVod({ 
-        sessionId: this._sessionId, 
-        category: this._category, 
-        playlistId: this._sessionId
-      })
-      .then(nextVod => {
+      let nextVodPromise;
+
+      if (!sessionState.nextVod) {
+        nextVodPromise = this._assetManager.getNextVod({ 
+          sessionId: this._sessionId, 
+          category: this._category, 
+          playlistId: this._sessionId
+        });
+      } else {
+        nextVodPromise = new Promise((success, fail) => {
+          debug(`[${this._sessionId}]: Reading nextVod response from session store`);
+          success(sessionState.nextVod);
+        });
+      }
+
+      nextVodPromise.then(nextVod => {
         if (nextVod && nextVod.uri) {
           this.currentMetadata = {
             id: nextVod.id,

--- a/engine/session_state.js
+++ b/engine/session_state.js
@@ -82,6 +82,10 @@ class SharedSessionState {
   async set(key, value) {
     return await this.store.set(this.sessionId, key, value);
   }
+  
+  async remove(key) {
+    await this.store.remove(this.sessionId, key);
+  }
 }
 
 class SessionStateStore extends SharedStateStore {

--- a/engine/session_state.js
+++ b/engine/session_state.js
@@ -10,8 +10,9 @@ const SessionState = Object.freeze({
 });
 
 class SharedSessionState {
-  constructor(store, sessionId, opts) {
+  constructor(store, sessionId, instanceId, opts) {
     this.sessionId = sessionId;
+    this.instanceId = instanceId;
     this.cache = {
       currentVod: {
         ts: 0,
@@ -86,6 +87,22 @@ class SharedSessionState {
   async remove(key) {
     await this.store.remove(this.sessionId, key);
   }
+
+  async increment(key) {
+    let incrementer = await this.store.get(this.sessionId, "incrementer");
+    if (!incrementer) {
+      incrementer = this.instanceId;
+      await this.store.setVolatile(this.sessionId, "incrementer", this.instanceId);
+    }
+    let value = await this.get(key);
+    if (incrementer === this.instanceId) {
+      debug(`[${this.sessionId}]: I am incrementing key ${key}`);
+      value += 1;
+      return await this.set(key, value);
+    } else {
+      return value;
+    }
+  }
 }
 
 class SessionStateStore extends SharedStateStore {
@@ -109,9 +126,9 @@ class SessionStateStore extends SharedStateStore {
     }
   }
 
-  async create(sessionId) {
+  async create(sessionId, instanceId) {
     await this.init(sessionId);
-    return new SharedSessionState(this, sessionId, { cacheTTL: this.cacheTTL || 5000 });
+    return new SharedSessionState(this, sessionId, instanceId, { cacheTTL: this.cacheTTL || 5000 });
   }
 }
 

--- a/engine/shared_state_store.js
+++ b/engine/shared_state_store.js
@@ -58,6 +58,10 @@ class SharedStateStore {
     }
     return data;
   }
+
+  async remove(id, key) {
+    await this.store.removeAsync(id, key);
+  }
 }
 
 module.exports = SharedStateStore;

--- a/engine/shared_state_store.js
+++ b/engine/shared_state_store.js
@@ -51,6 +51,11 @@ class SharedStateStore {
     return data;
   }
 
+  async setVolatile(id, key, value) {
+    const data = await this.store.setVolatileAsync(id, key, value);
+    return data;
+  }
+
   async getValues(id, keys) {
     let data = {};
     for(const key of keys) {


### PR DESCRIPTION
This PR resolves the issue where multiple nodes were incrementing the media sequences at the same time.

To make sure that only one node is incrementing the media sequence state we set a volatile key (a key that expires) in the shared session store that indicates which instance is the "incrementer". This key is volatile which means that if the current incrementer would crash the next one (first come - first served) will take over that role if that key is missing (has expired).

This PR also includes that the next vod response from the asset manager is also stored in shared store.