### PR TITLE
fix/live vod2live

### DIFF
--- a/engine/stream_switcher.js
+++ b/engine/stream_switcher.js
@@ -50,9 +50,9 @@ class StreamSwitcher {
     // If no more live streams, and streamType is live switch back to vod2live
     if (schedule.length === 0 && this.streamTypeLive) {
       await this._initSwitching(
-        SwitcherState.LIVE_TO_VOD, 
-        session, 
-        sessionLive, 
+        SwitcherState.LIVE_TO_VOD,
+        session,
+        sessionLive,
         null
       );
       return false;
@@ -78,13 +78,12 @@ class StreamSwitcher {
     }
     // Case: Live->Live
     if (schedule.length > 0 && this.streamTypeLive) {
-      const nextScheduleObj = schedule[0];
-      if (tsNow >= nextScheduleObj.start && this.streamID !== nextScheduleObj.id) {
+      if (tsNow >= scheduleObj.start && this.streamID !== scheduleObj.id) {
         await this._initSwitching(
           SwitcherState.LIVE_TO_LIVE,
           session,
           sessionLive,
-          nextScheduleObj
+          scheduleObj
         );
         return true;
       }
@@ -103,12 +102,12 @@ class StreamSwitcher {
       return true;
     }
     // GO BACK TO V2L? Then:
-    if (strmSchedule.length !== schedule.length && this.streamTypeLive) {
+    if (tsNow < scheduleObj.start && this.streamTypeLive) {
       // We are past the end point for the scheduled Live stream
       await this._initSwitching(
-        SwitcherState.LIVE_TO_VOD, 
-        session, 
-        sessionLive, 
+        SwitcherState.LIVE_TO_VOD,
+        session,
+        sessionLive,
         null
       );
       return false;

--- a/server.js
+++ b/server.js
@@ -64,19 +64,30 @@ class RefChannelManager {
   }
 }
 
-const tsNow = Date.now();
 class StreamSwitchManager {
+  constructor() {
+    this.schedule = [];
+    this.scheduleID = 0;
+  }
   getSchedule() {
-    // Break in with live content after 20 seconds of VOD2Live and let it play for 60 seconds
-    let schedule = [
-      {
-        id: "abc-100",
-        start: tsNow + 20 * 1000,
-        estEnd: tsNow + 20 * 1000 + 1 * 60 * 1000,
+    const tsNow = Date.now();
+    const liveStreamDuration = 1 * 60 * 1000;
+    const startOffset = tsNow + liveStreamDuration;
+    const endTime = startOffset + liveStreamDuration;
+    // Break in with live content after 1 minute of VOD2Live the first time Channel Engine starts
+    // and let it play for 1 minute then break in with live content after 1 minute of VOD2Live and let it run for 1 minute
+    console.log(JSON.stringify(this.schedule));
+    this.schedule = this.schedule.filter((obj) => obj.estEnd >= tsNow);
+    if (this.schedule.length === 0) {
+      this.schedule.push({
+        id: this.scheduleID++,
+        start: startOffset,
+        estEnd: endTime,
         uri: "https://cph-p2p-msl.akamaized.net/hls/live/2000341/test/master.m3u8",
-      },
-    ];
-    return schedule;
+      });
+    }
+
+    return this.schedule;
   }
 }
 


### PR DESCRIPTION
* Fix for the live->vod2live when fetching all media manifests sometimes could be out of sync.

* Pausing the stream for a longer time period could cause an issue where the session got a negative index.

* Stream switcher would not consider the case where the schedule would be updated by the schedule manager.