### PR TITLE
Fix for bug where stream switcher returns undefined

### DIFF
--- a/engine/server.js
+++ b/engine/server.js
@@ -176,12 +176,14 @@ class ChannelEngine {
     const getSwitchStatusAndPerformSwitch = async (channel) => {
       if (sessionSwitchers[channel]) {
         const switcher = sessionSwitchers[channel];
+        let prevStatus = switcherStatus[channel] !== null ? switcherStatus[channel] : null;
         switcherStatus[channel] = null;
         let status = null;
         try {
           status = await switcher.streamSwitcher(sessions[channel], sessionsLive[channel]);
           if (status === undefined) {
-            debug(`[WARNING]: switcherStatus->${status}`);
+            debug(`[WARNING]: switcherStatus->${status}___setting to->${prevStatus}`);
+            status = prevStatus;
           }
           switcherStatus[channel] = status;
         } catch (err) {

--- a/engine/server.js
+++ b/engine/server.js
@@ -182,7 +182,7 @@ class ChannelEngine {
         try {
           status = await switcher.streamSwitcher(sessions[channel], sessionsLive[channel]);
           if (status === undefined) {
-            debug(`[WARNING]: switcherStatus->${status}___setting to->${prevStatus}`);
+            debug(`[WARNING]: switcherStatus->${status}. Setting value to previous status->${prevStatus}`);
             status = prevStatus;
           }
           switcherStatus[channel] = status;


### PR DESCRIPTION
When endpoint `_handleMediaManifest` gets a request from a client, it is to wait for the stream switcher's verdict on the specific channel/session. Basically, shall the endpoint return an m3u8 from Session or SessionLive? (switcher returns true or false)

If the stream switcher is ever busy (preparing a switch between Session & SessionLive), the endpoint will wait for the completion. We do not want to return any manifest in this situation since the playheads do not wait for the switcher, and might return a manifest it shouldn't. 

If the switching is slow or fails, it will try again. If too much time passes then the request will cancel (timeout I believe).

However, there is a bug where the stream switcher instantly returns the value '**undefined**'. 
The absolute cause is atm unknown, a switcher has only booleans as return values, and any error internally should be caught and we never caught anything when this bug happens.
-It most often occurs right before a switch, or right after, occasionally.
-And only channels which are getting client requests at that time will trigger this outcome.
-Furthermore, it has been shown to persist long enough to invoke a request timeout, before returning booleans again.

Until the cause can be pinned down, I propose a fix where we return the last used boolean value whenever we encounter an 'undefined' return value. This will at least reduce the frequency of canceled requests due to timeouts. And it shouldn't risk returning an m3u8 it shouldn't since this bug seemingly never happens on a switch between Session&SessionLive. 


