### PR TITLE
Example/add stream switch mgr api

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ const engine = new ChannelEngine(refAssetManager, engineOptions);
 engine.start();
 engine.listen(process.env.port || 8000);
 ```
-A StreamSwitcher component in the channel engine will continiously, in a set time interval, use the StreamSwitchManager to get the list and will inspect whether it should break into/out of the event, depending on the current time. 
+A StreamSwitcher component in the channel engine will continiously, in a set time interval, use the StreamSwitchManager to get the list and filter out all events whos `end_time` has passed, and will inspect whether it should break into/out of the next event in the remaining list, depending on the current time. 
 
 Note that this feature is also currently in beta which means that it is close to production-ready but has not been run in production yet. We appreciate all efforts to try this out and provide feedback.
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The class's `getSchedule()` function should return a list of event objects in th
 {
   "eventId": {
       "type": "string",
-      "description": "Generated ID of the event. If not specified a uuid-based eventId will be generated"
+      "description": "Generated ID of the event"
   },
   "assetId": {
     "type": "string",
@@ -200,6 +200,9 @@ Below are examples of a Live stream event and a VOD event respectively:
   duration: 2 * 60 * 1000,
 }
 ```
+(*Important Note: When it comes to VOD events. Desired `duration` has priority over `end_time`. Meaning that you will only resume VOD2Live content after the asset in the VOD event has finished. This may change in the future.*) 
+
+
 Then create an instance of the class and reference it as the `streamSwitchManager` in your engineOptions, just like you'd do with the channel manager. 
 
 ```

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Available options when constructing the Channel Engine object are:
 - `sharedStoreCacheTTL`: How long should data be cached in memory before writing to shared store. Default is 1000 ms.
 - `heartbeat`: Path for heartbeat requests
 - `channelManager`: A reference to a channel manager object.
+- `streamSwitchManager`: A reference to a stream switch manager object.
 - `cacheTTL`: Sets the cache-control header TTL. Default is 4 sec.
 - `playheadDiffThreshold`: Sets the threshold when starting to adjust tick interval to compensate for playhead drift.
 - `maxTickInterval`: The maximum interval for playhead tick interval. Default is 10000 ms.
@@ -119,6 +120,108 @@ engine.listen(process.env.port || 8000);
 ```
 
 Note that this feature is currently in beta which means that it is close to production-ready but has not been run in production yet. We appreciate all efforts to try this out and provide feedback.
+
+
+## Live Mixing (BETA)
+
+This feature gives the possibility to mix in a true live stream in a Channel Engine powered linear channel (VOD2Live).
+
+![RFC Drawing of Live-Mixing Functionality](rfc/channel_engine_vod_with_live.png)
+
+A beta-version of live-mixing with high availability support is available in the Channel Engine. This allows you to use a new component which can let you break in to a scheduled VOD event or Live stream event at any speficied time on top of the usual vod-to-live content. 
+To enable live-mixing, create a class which implements the following interface.
+
+```
+class MyStreamSwitchManager {
+  getSchedule() -> [ { eventId, assetId, title, type, start_time, end_time, uri, duration } ]
+}
+```
+
+The class's `getSchedule()` function should return a list of event objects in the following format:
+
+```
+{
+  "eventId": {
+      "type": "string",
+      "description": "Generated ID of the event. If not specified a uuid-based eventId will be generated"
+  },
+  "assetId": {
+    "type": "string",
+    "description": "The ID of the asset in the schedule event"
+  },
+  "title": {
+    "type": "string",
+    "description": "Title of the asset"
+  },
+  "type": {
+    "type": "number",
+    "description": "Type of event (1=LIVE and 2=VOD)"
+  },
+  "start_time": {
+    "type": "number",
+    "description": "UTC Start time of the event as a Unix Timestamp (in milliseconds)"
+  },
+  "end_time": {
+    "type": "number",
+    "description": "UTC End time of the event as a Unix Timestamp (in milliseconds)"
+  },
+  "uri": {
+    "type": "string",
+    "description": "The URI to the VOD asset or Live Stream"
+  },
+  "duration": {
+    "type": "number",
+    "description": "The duration of the asset (in milliseconds) NOTE: Not required for Live Stream events"
+  }
+}
+```
+
+Below are examples of a Live stream event and a VOD event respectively:
+```
+{
+  eventId: "eeecd5ce-d2d2-48db-b1b3-233957f7d69e",
+  assetId: "live-asset-4",
+  title: "My scheduled Live stream event",
+  type: 1,
+  start_time: 1631003900000,
+  end_time: 1631003921000,
+  uri: "https://cph-p2p-msl.akamaized.net/hls/live/2000341/test/master.m3u8",
+}
+```
+```
+{
+  eventId: "26453eea-0ac2-4b89-a87a-73d369920874",
+  assetId: "vod-asset-13",
+  title: "My scheduled VOD event",
+  type: 2,
+  start_time: 1631004100000,
+  end_time: 1631004121000,
+  uri: "https://maitv-vod.lab.eyevinn.technology/VINN.mp4/master.m3u8",
+  duration: 2 * 60 * 1000,
+}
+```
+Then create an instance of the class and reference it as the `streamSwitchManager` in your engineOptions, just like you'd do with the channel manager. 
+
+```
+const MyStreamSwitchManager = new MyStreamSwitchManager();
+
+const engineOptions = {
+  heartbeat: '/',
+  averageSegmentDuration: 2000,
+  channelManager: MyChannelManager,
+  defaultSlateUri: "https://maitv-vod.lab.eyevinn.technology/slate-consuo.mp4/master.m3u8",
+  slateRepetitions: 10,
+  redisUrl: "redis://127.0.0.1",
+  streamSwitchManager: MyStreamSwitchManager,
+};
+
+const engine = new ChannelEngine(refAssetManager, engineOptions);
+engine.start();
+engine.listen(process.env.port || 8000);
+```
+A StreamSwitcher component in the channel engine will continiously, in a set time interval, use the StreamSwitchManager to get the list and will inspect whether it should break into/out of the event, depending on the current time. 
+
+Note that this feature is also currently in beta which means that it is close to production-ready but has not been run in production yet. We appreciate all efforts to try this out and provide feedback.
 
 ## Demo
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,9 @@ services:
     image: channel-engine:test
     environment:
       - PORT=8081
-      - TEST_CHANNELS=5
+      - TEST_CHANNELS=3
       - REDIS_URL=redis://redis:6379/
+      - SWITCH_MGR_URL=http://localhost:8001/api/v1/schedule
     networks:
       - vc-net
     ports:
@@ -24,8 +25,9 @@ services:
     image: channel-engine:test
     environment:
       - PORT=8082
-      - TEST_CHANNELS=5
+      - TEST_CHANNELS=3
       - REDIS_URL=redis://redis:6379/
+      - SWITCH_MGR_URL=http://localhost:8001/api/v1/schedule
     networks:
       - vc-net
     ports:

--- a/engine/stream_switcher.js
+++ b/engine/stream_switcher.js
@@ -68,7 +68,7 @@ class StreamSwitcher {
     let status = null;
     // Filter out schedule objects from the past
     const tsNow = Date.now(); 
-    const strmSchedule = this.streamSwitchManager.getSchedule();
+    const strmSchedule = await this.streamSwitchManager.getSchedule(this.sessionId);
     const schedule = strmSchedule.filter((obj) => obj.end_time > tsNow);   
     if (schedule.length === 0 && this.streamTypeLive) {
       status = await this._initSwitching(

--- a/server.js
+++ b/server.js
@@ -113,42 +113,45 @@ const StreamType = Object.freeze({
 class StreamSwitchManager {
   constructor() {
     this.schedule = [];
+    this.BREAKING_ENDPOINT = process.env.SWITCH_MGR_URL || "http://localhost:8001/api/v1/schedule/";
   }
 
   generateID() {
     return uuidv4();
   }
 
-  getSchedule() {
-    const tsNow = Date.now();
-    const streamDuration = 60 * 1000;
-    const startOffset = tsNow + streamDuration;
-    const endTime = startOffset + 3*streamDuration;
-    // Break in with live and scheduled VOD content after 60 seconds of VOD2Live the first time Channel Engine starts
-    // Required: "assetId", "start_time", "end_time", "uri", "duration"
-    // "duration" is only required for StreamType.VOD
-    this.schedule = this.schedule.filter((obj) => obj.end_time >= tsNow);
-    if (this.schedule.length === 0) {
-      this.schedule.push({
-        eventId: this.generateID(),
-        assetId: this.generateID(),
-        title: "Live stream test",
-        type: StreamType.LIVE,
-        start_time: startOffset,
-        end_time: endTime,
-        uri: "https://cph-p2p-msl.akamaized.net/hls/live/2000341/test/master.m3u8",
-      },
-      {
-        eventId: this.generateID(),
-        assetId: this.generateID(),
-        title: "Scheduled VOD test",
-        type: StreamType.VOD,
-        start_time: (endTime + 100*1000),
-        end_time: (endTime + 100*1000) + streamDuration,
-        uri: "https://maitv-vod.lab.eyevinn.technology/COME_TO_DADDY_Trailer_2020.mp4/master.m3u8",
-        duration: streamDuration,
-      });
-    }
+  async getSchedule(channelId) {
+
+
+    // const tsNow = Date.now();
+    // const streamDuration = 60 * 1000;
+    // const startOffset = tsNow + streamDuration;
+    // const endTime = startOffset + 3*streamDuration;
+    // // Break in with live and scheduled VOD content after 60 seconds of VOD2Live the first time Channel Engine starts
+    // // Required: "assetId", "start_time", "end_time", "uri", "duration"
+    // // "duration" is only required for StreamType.VOD
+    // this.schedule = this.schedule.filter((obj) => obj.end_time >= tsNow);
+    // if (this.schedule.length === 0) {
+    //   this.schedule.push({
+    //     eventId: this.generateID(),
+    //     assetId: this.generateID(),
+    //     title: "Live stream test",
+    //     type: StreamType.LIVE,
+    //     start_time: startOffset,
+    //     end_time: endTime,
+    //     uri: "https://cph-p2p-msl.akamaized.net/hls/live/2000341/test/master.m3u8",
+    //   },
+    //   {
+    //     eventId: this.generateID(),
+    //     assetId: this.generateID(),
+    //     title: "Scheduled VOD test",
+    //     type: StreamType.VOD,
+    //     start_time: (endTime + 100*1000),
+    //     end_time: (endTime + 100*1000) + streamDuration,
+    //     uri: "https://maitv-vod.lab.eyevinn.technology/COME_TO_DADDY_Trailer_2020.mp4/master.m3u8",
+    //     duration: streamDuration,
+    //   });
+    // }
     return this.schedule;
   }
 }


### PR DESCRIPTION
This version adds a new reference implemetation of a StreamSwitchManager using the [Breaking News API](https://github.com/Eyevinn/breaking-news-vc)

Furthermore, some changes had to be made to in `stream_switcher.js` to allow for channel specified event switching.