### PR TITLE
feat: add an additional playback endpoint

### DIFF
--- a/engine/server.js
+++ b/engine/server.js
@@ -83,7 +83,7 @@ class ChannelEngine {
     if (options && options.forceTargetDuration) {
       this.streamerOpts.forceTargetDuration = options.forceTargetDuration;
     }
-    this.server.get('/live/:file', async (req, res, next) => {
+    const handleMasterRoute = async (req, res, next) => {
       debug(req.params);
       let m;
       if (req.params.file.match(/master.m3u8/)) {
@@ -98,6 +98,14 @@ class ChannelEngine {
         req.params[2] = m[3];
         await this._handleAudioManifest(req, res, next);
       }
+    };
+    
+    this.server.get('/live/:file', async (req, res, next) => {
+      await handleMasterRoute(req, res, next);
+    });
+    this.server.get('/channels/:channelId/:file', async (req, res, next) => {
+      req.query['channel'] = req.params.channelId;
+      await handleMasterRoute(req, res, next);
     });
     this.server.get('/eventstream/:sessionId', this._handleEventStream.bind(this));
     this.server.get('/status/:sessionId', this._handleStatus.bind(this));


### PR DESCRIPTION
This PR resolves #100 by adding an additional playback endpoint `/channels/:channelId/master.m3u8` that is equal to `/live/master.m3u8?channel=:channelId`