### PR TITLE
preserve ad markers when transition from V2L->Live

### DIFF
--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -249,6 +249,9 @@ class SessionLive {
       if (!segments[bw][segments[bw].length - 1].discontinuity) {
         this.vodSegments[bw].push({ discontinuity: true });
       }
+      if(segments[bw][0].cue) {
+        this.vodSegments[bw].push(segments[bw][0].cue);
+      }
     }
 
     for (let segIdx = 0; segIdx < segments[allBws[0]].length; segIdx++) {
@@ -1066,6 +1069,28 @@ class SessionLive {
           m3u8 += vodSeg.uri + "\n";
         } else {
           m3u8 += "#EXT-X-DISCONTINUITY\n";
+        }
+        if (vodSeg.cue) {
+          if (vodSeg.cue.in){
+            m3u8 += "#EXT-X-CUE-IN" + "\n";
+          }
+          if(vodSeg.cue.out) {
+            if (vodSeg.cue.scteData) {
+              m3u8 += "#EXT-OATCLS-SCTE35:" + vodSeg.cue.scteData + "\n";
+            }
+            if (vodSeg.cue.assetData) {
+              m3u8 += "#EXT-X-ASSET:" + vodSeg.cue.assetData + "\n";
+            }
+            m3u8 += "#EXT-X-CUE-OUT:DURATION=" + vodSeg.cue.duration + "\n";
+          }
+          if (vodSeg.cue.cont) {
+            if (vodSeg.cue.scteData) {
+              m3u8 += "#EXT-X-CUE-OUT-CONT:ElapsedTime=" + vodSeg.cue.cont + ",Duration=" + vodSeg.cue.duration + ",SCTE35=" + vodSeg.cue.scteData + "\n";
+            }
+            else {
+              m3u8 += "#EXT-X-CUE-OUT-CONT:" + vodSeg.cue.cont + "/" + vodSeg.cue.duration + "\n";
+            }
+          }
         }
       }
       // Add live-source segments

--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -501,7 +501,7 @@ class SessionLive {
 
         let segCount = 0;
         this.liveSegQueue[bw].map((seg) => {if (seg.uri) { segCount++ }});
-        if (segCount >= this.targetNumSeg) {
+        if (segCount > this.targetNumSeg) {
           seg = this.liveSegQueue[bw].shift();
           if (seg && seg.discontinuity || seg && seg.cue) {
             if (seg.discontinuity) {
@@ -1030,7 +1030,7 @@ class SessionLive {
         let segCount = 0;
         this.liveSegQueue[liveTargetBandwidth].map((seg) => {if (seg.uri) { segCount++ }});
         debug(`[${this.sessionId}]: size of queue=${segCount}_targetNumseg=${this.targetNumSeg}`);
-        if (segCount >= this.targetNumSeg) {
+        if (segCount > this.targetNumSeg) {
           seg = this.liveSegQueue[liveTargetBandwidth].shift();
           if (seg && seg.discontinuity || seg && seg.cue) {
             if (seg.discontinuity) {

--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -487,6 +487,9 @@ class SessionLive {
           this.vodSegments[vodBws[i]].shift();
         }
       }
+      if (incrementDiscSeqCount) {
+        this.mediaSeqCount++;
+      }
       // Push to bottom, new live source segment on all variants
       for (let i = 0; i < liveBws.length; i++) {
         const bw = liveBws[i];
@@ -517,8 +520,6 @@ class SessionLive {
       }
       if (incrementDiscSeqCount) {
         this.discSeqCount++;
-        // Do not increase counter if top segment is a disc tag
-        this.mediaSeqCount--;
       }
       this.mediaSeqCount++;
     }
@@ -847,8 +848,6 @@ class SessionLive {
       }
       if (incrementDiscSeqCount) {
         this.discSeqCount++;
-        // Do not increase counter if top segment is a disc tag
-        this.mediaSeqCount--;
       }
       this.mediaSeqCount++;
     }

--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -517,6 +517,8 @@ class SessionLive {
       }
       if (incrementDiscSeqCount) {
         this.discSeqCount++;
+        // Do not increase counter if top segment is a disc tag
+        this.mediaSeqCount--;
       }
       this.mediaSeqCount++;
     }
@@ -845,6 +847,8 @@ class SessionLive {
       }
       if (incrementDiscSeqCount) {
         this.discSeqCount++;
+        // Do not increase counter if top segment is a disc tag
+        this.mediaSeqCount--;
       }
       this.mediaSeqCount++;
     }

--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -116,7 +116,7 @@ class SessionLive {
     this.waitForPlayhead = true;
     this.blockGenerateManifest = false;
 
-    debug(`[${this.instanceId}][${this.sessionId}]: Resetting all proprerty values in sessionLive`);
+    debug(`[${this.instanceId}][${this.sessionId}]: Resetting all property values in sessionLive`);
   }
 
   async startPlayheadAsync() {
@@ -231,7 +231,7 @@ class SessionLive {
     }
     // Make it possible to add & share new segments
     this.allowedToSet = true;
-    let discCount = 0;
+    let segCount = 0;
     const allBws = Object.keys(segments);
     for (let i = 0; i < allBws.length; i++) {
       const bw = allBws[i];
@@ -249,17 +249,14 @@ class SessionLive {
       if (!segments[bw][segments[bw].length - 1].discontinuity) {
         this.vodSegments[bw].push({ discontinuity: true });
       }
-      if(segments[bw][0].cue) {
-        this.vodSegments[bw].push(segments[bw][0].cue);
-      }
     }
 
     for (let segIdx = 0; segIdx < segments[allBws[0]].length; segIdx++) {
-      if (segments[allBws[0]][segIdx].discontinuity) {
-        discCount++;
+      if (segments[allBws[0]][segIdx].uri) {
+        segCount++;
       }
     }
-    this.targetNumSeg = this.vodSegments[allBws[0]].length - discCount;
+    this.targetNumSeg = segCount;
     debug(`[${this.sessionId}]: Setting CurrentMediaSequenceSegments. First seg is: [${this.vodSegments[allBws[0]][0].uri}]`);
 
     const isLeader = await this.sessionLiveStateStore.isLeader(this.instanceId);
@@ -473,14 +470,20 @@ class SessionLive {
     debug(`[${this.sessionId}]: [size=${size}]->this.liveSegsForFollowers=${Object.keys(this.liveSegsForFollowers)} `);
     // Remove transitional segs & add live source segs collected from store
     for (let k = 0; k < size; k++) {
-      // Increase Discontinuity count if top segment is a discontinuity segment
-      if (this.vodSegments[vodBws[0]].length !== 0 && this.vodSegments[vodBws[0]][0].discontinuity) {
-        this.discSeqCount++;
-      }
+      let incrementDiscSeqCount = false;
       // Shift the top vod segment on all variants
       for (let i = 0; i < vodBws.length; i++) {
         let seg = this.vodSegments[vodBws[i]].shift();
-        if (seg && seg.discontinuity) {
+        if (seg && seg.discontinuity || seg && seg.cue) {
+          if (seg.discontinuity) {
+            incrementDiscSeqCount = true;
+          }
+          seg = this.vodSegments[vodBws[i]].shift();
+        }
+        if (seg && seg.discontinuity || seg && seg.cue) {
+          if (seg.discontinuity) {
+            incrementDiscSeqCount = true;
+          }
           this.vodSegments[vodBws[i]].shift();
         }
       }
@@ -492,10 +495,28 @@ class SessionLive {
           this.liveSegQueue[bw] = [];
         }
         this.liveSegQueue[bw].push(liveSegFromLeader);
-        if (this.liveSegQueue[bw].length >= this.targetNumSeg) {
-          this.liveSegQueue[bw].shift();
+
+        let segCount = 0;
+        this.liveSegQueue[bw].map((seg) => {if (seg.uri) { segCount++ }});
+        if (segCount >= this.targetNumSeg) {
+          seg = this.liveSegQueue[bw].shift();
+          if (seg && seg.discontinuity || seg && seg.cue) {
+            if (seg.discontinuity) {
+              incrementDiscSeqCount = true;
+            }
+            seg = this.liveSegQueue[bw].shift();
+          }
+          if (seg && seg.discontinuity || seg && seg.cue) {
+            if (seg.discontinuity) {
+              incrementDiscSeqCount = true;
+            }
+            this.liveSegQueue[bw].shift();
+          }
         }
         debug(`[${this.sessionId}]: Pushed a segment to 'liveSegQueue'`);
+      }
+      if (incrementDiscSeqCount) {
+        this.discSeqCount++;
       }
       this.mediaSeqCount++;
     }
@@ -607,7 +628,7 @@ class SessionLive {
           debug(`[${this.sessionId}]: Pushed loadMedia promise for bw=[${bw}]`);
         }
         // Fetch From Live Source
-        debug(`[${this.sessionId}]: Executing Promises I: Fetech From Live Source`);
+        debug(`[${this.sessionId}]: Executing Promises I: Fetch From Live Source`);
         manifestList = await allSettled(livePromises);
         livePromises = [];
       } catch (err) {
@@ -805,19 +826,27 @@ class SessionLive {
   async _incrementAndShift() {
     const vodBandwidths = Object.keys(this.vodSegments);
     for (let j = 0; j < this.pushAmount; j++) {
-      // Increase Media Sequence Count
-      this.mediaSeqCount++;
-      // Increase Discontinuity count if top segment is a discontinuity segment
-      if (this.vodSegments[vodBandwidths[0]].length != 0 && this.vodSegments[vodBandwidths[0]][0].discontinuity) {
-        this.discSeqCount++;
-      }
+      let incrementDiscSeqCount = false;
       // Shift the top vod segment
       for (let i = 0; i < vodBandwidths.length; i++) {
         let seg = this.vodSegments[vodBandwidths[i]].shift();
-        if (seg && seg.discontinuity) {
+        if (seg && seg.discontinuity || seg && seg.cue) {
+          if (seg.discontinuity) {
+            incrementDiscSeqCount = true;
+          }
+          seg = this.vodSegments[vodBandwidths[i]].shift();
+        }
+        if (seg && seg.discontinuity || seg && seg.cue) {
+          if (seg.discontinuity) {
+            incrementDiscSeqCount = true;
+          }
           this.vodSegments[vodBandwidths[i]].shift();
         }
       }
+      if (incrementDiscSeqCount) {
+        this.discSeqCount++;
+      }
+      this.mediaSeqCount++;
     }
 
     // TODO: LASTLY: SHRINK IF NEEDED. (should only happen once if ever.)
@@ -952,12 +981,39 @@ class SessionLive {
   }
 
   _addLiveSegmentsToQueue(startIdx, playlistItems, baseUrl, liveTargetBandwidth) {
+    let incrementDiscSeqCount = false;
     for (let i = startIdx; i < playlistItems.length; i++) {
       debug(`[${this.sessionId}]: Adding Live Segment(s) to Queue (for bw=${liveTargetBandwidth})`);
       let seg = {};
       let playlistItem = playlistItems[i];
       let segmentUri;
-      if (!playlistItem.properties.discontinuity) {
+      let attributes = playlistItem.attributes.attributes;
+
+      if ("cuein" in attributes) {
+        this.liveSegQueue[liveTargetBandwidth].push({ cue: { in: true } });
+        this.liveSegsForFollowers[liveTargetBandwidth].push({ cue: { in: true } });
+      }
+      if ("cueout" in attributes) {
+        this.liveSegQueue[liveTargetBandwidth].push({ cue: { out: true}, duration: attributes["cueout"] });
+        this.liveSegsForFollowers[liveTargetBandwidth].push({ cue: { out: true }, duration: attributes["cueout"] });
+      }
+      if ("cuecont" in attributes) {
+        this.liveSegQueue[liveTargetBandwidth].push({ cue: { cont: true } });
+        this.liveSegsForFollowers[liveTargetBandwidth].push({ cue: { cont: true } });
+      }
+      if ("scteData" in attributes) {
+        this.liveSegQueue[liveTargetBandwidth].push({ cue: { scteData: attributes["scteData"] } });
+        this.liveSegsForFollowers[liveTargetBandwidth].push({ cue: { scteData: attributes["scteData"] } });
+      }
+      if ("scteData" in attributes) {
+        this.liveSegQueue[liveTargetBandwidth].push({ cue: { assetData: attributes["assetData"] } });
+        this.liveSegsForFollowers[liveTargetBandwidth].push({ cue: { assetData: attributes["assetData"] } });
+      }
+      if (playlistItem.properties.discontinuity) {
+        this.liveSegQueue[liveTargetBandwidth].push({ discontinuity: true });
+        this.liveSegsForFollowers[liveTargetBandwidth].push({ discontinuity: true });
+      }
+      if (playlistItem.properties.uri) {
         if (playlistItem.properties.uri.match("^http")) {
           segmentUri = playlistItem.properties.uri;
         } else {
@@ -965,25 +1021,31 @@ class SessionLive {
         }
         seg["duration"] = playlistItem.properties.duration;
         seg["uri"] = segmentUri;
-        //debug(`[${this.sessionId}]: X | PUSHED this segment to the QUEUE:${JSON.stringify(seg)}`);
+
         this.liveSegQueue[liveTargetBandwidth].push(seg);
         this.liveSegsForFollowers[liveTargetBandwidth].push(seg);
-        let sizeOfQueue = this.liveSegQueue[liveTargetBandwidth].length;
-        //debug(`[${this.sessionId}]: size of queue=${sizeOfQueue}_targetNumseg=${this.targetNumSeg}`);
-        if (sizeOfQueue >= this.targetNumSeg) {
-          this.liveSegQueue[liveTargetBandwidth].shift();
-        }
-      } else {
-        //debug(`[${this.sessionId}]: X | PUSHED a DISCONTINUITY tag to the QUEUE`);
-        this.liveSegQueue[liveTargetBandwidth].push({ discontinuity: true });
-        this.liveSegsForFollowers[liveTargetBandwidth].push({
-          discontinuity: true,
-        });
-        let sizeOfQueue = this.liveSegQueue[liveTargetBandwidth].length;
-        if (sizeOfQueue >= this.targetNumSeg) {
-          this.liveSegQueue[liveTargetBandwidth].shift();
+        let segCount = 0;
+        this.liveSegQueue[liveTargetBandwidth].map((seg) => {if (seg.uri) { segCount++ }});
+        debug(`[${this.sessionId}]: size of queue=${segCount}_targetNumseg=${this.targetNumSeg}`);
+        if (segCount >= this.targetNumSeg) {
+          seg = this.liveSegQueue[liveTargetBandwidth].shift();
+          if (seg && seg.discontinuity || seg && seg.cue) {
+            if (seg.discontinuity) {
+              incrementDiscSeqCount = true;
+            }
+            seg = this.liveSegQueue[liveTargetBandwidth].shift();
+          }
+          if (seg && seg.discontinuity || seg && seg.cue) {
+            if (seg.discontinuity) {
+              incrementDiscSeqCount = true;
+            }
+            this.liveSegQueue[liveTargetBandwidth].shift();
+          }
         }
       }
+    }
+    if (incrementDiscSeqCount) {
+      this.discSeqCount++;
     }
   }
 
@@ -1062,47 +1124,47 @@ class SessionLive {
     if (Object.keys(this.vodSegments).length !== 0) {
       // Add transitional segments if there are any left.
       debug(`[${this.sessionId}]: Adding a Total of (${this.vodSegments[vodTargetBandwidth].length}) VOD segments to manifest`);
-      for (let i = 0; i < this.vodSegments[vodTargetBandwidth].length; i++) {
-        let vodSeg = this.vodSegments[vodTargetBandwidth][i];
-        if (!vodSeg.discontinuity) {
-          m3u8 += "#EXTINF:" + vodSeg.duration.toFixed(3) + ",\n";
-          m3u8 += vodSeg.uri + "\n";
-        } else {
-          m3u8 += "#EXT-X-DISCONTINUITY\n";
-        }
-        if (vodSeg.cue) {
-          if (vodSeg.cue.in){
-            m3u8 += "#EXT-X-CUE-IN" + "\n";
-          }
-          if(vodSeg.cue.out) {
-            if (vodSeg.cue.scteData) {
-              m3u8 += "#EXT-OATCLS-SCTE35:" + vodSeg.cue.scteData + "\n";
-            }
-            if (vodSeg.cue.assetData) {
-              m3u8 += "#EXT-X-ASSET:" + vodSeg.cue.assetData + "\n";
-            }
-            m3u8 += "#EXT-X-CUE-OUT:DURATION=" + vodSeg.cue.duration + "\n";
-          }
-          if (vodSeg.cue.cont) {
-            if (vodSeg.cue.scteData) {
-              m3u8 += "#EXT-X-CUE-OUT-CONT:ElapsedTime=" + vodSeg.cue.cont + ",Duration=" + vodSeg.cue.duration + ",SCTE35=" + vodSeg.cue.scteData + "\n";
-            }
-            else {
-              m3u8 += "#EXT-X-CUE-OUT-CONT:" + vodSeg.cue.cont + "/" + vodSeg.cue.duration + "\n";
-            }
-          }
-        }
-      }
+      m3u8 = this._setMediaManifestTags(this.vodSegments, m3u8, vodTargetBandwidth);
+      this.liveSegQueue[liveTargetBandwidth].map((item) => console.log(JSON.stringify(item)));
       // Add live-source segments
-      for (let i = 0; i < this.liveSegQueue[liveTargetBandwidth].length; i++) {
-        const liveSeg = this.liveSegQueue[liveTargetBandwidth][i];
-        if (liveSeg.uri && liveSeg.duration) {
-          m3u8 += "#EXTINF:" + liveSeg.duration.toFixed(3) + ",\n";
-          m3u8 += liveSeg.uri + "\n";
+      m3u8 = this._setMediaManifestTags(this.liveSegQueue, m3u8, liveTargetBandwidth);
+    }
+    debug(`[${this.sessionId}]: Manifest Generation Complete!`);
+    return m3u8;
+  }
+
+  _setMediaManifestTags(segments, m3u8, bw) {
+    for (let i = 0; i < segments[bw].length; i++) {
+      const seg = segments[bw][i];
+      if (!seg.discontinuity) {
+        m3u8 += "#EXTINF:" + seg.duration.toFixed(3) + ",\n";
+        m3u8 += seg.uri + "\n";
+      } else {
+        m3u8 += "#EXT-X-DISCONTINUITY\n";
+      }
+      if (seg.cue) {
+        if (seg.cue.in){
+          m3u8 += "#EXT-X-CUE-IN" + "\n";
+        }
+        if(seg.cue.out) {
+          if (seg.cue.scteData) {
+            m3u8 += "#EXT-OATCLS-SCTE35:" + seg.cue.scteData + "\n";
+          }
+          if (seg.cue.assetData) {
+            m3u8 += "#EXT-X-ASSET:" + seg.cue.assetData + "\n";
+          }
+          m3u8 += "#EXT-X-CUE-OUT:DURATION=" + seg.cue.duration + "\n";
+        }
+        if (seg.cue.cont) {
+          if (seg.cue.scteData) {
+            m3u8 += "#EXT-X-CUE-OUT-CONT:ElapsedTime=" + seg.cue.cont + ",Duration=" + seg.cue.duration + ",SCTE35=" + seg.cue.scteData + "\n";
+          }
+          else {
+            m3u8 += "#EXT-X-CUE-OUT-CONT:" + seg.cue.cont + "/" + seg.cue.duration + "\n";
+          }
         }
       }
     }
-    debug(`[${this.sessionId}]: Manifest Generation Complete!`);
     return m3u8;
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eyevinn-channel-engine",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eyevinn-channel-engine",
-      "version": "3.0.0-rc.3",
+      "version": "3.0.0-rc.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@eyevinn/hls-repeat": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@eyevinn/hls-repeat": "^0.1.1",
         "@eyevinn/hls-truncate": "^0.1.0",
-        "@eyevinn/hls-vodtolive": "^1.16.2",
+        "@eyevinn/hls-vodtolive": "^1.16.4",
         "@eyevinn/m3u8": "^0.4.0",
         "abort-controller": "^3.0.0",
         "debug": "^3.2.7",
@@ -82,13 +82,13 @@
       }
     },
     "node_modules/@eyevinn/hls-vodtolive": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-1.16.2.tgz",
-      "integrity": "sha512-RBHlfz5g/mklRJZV0XjviOwo+EbCV0Z3maonQwkXWqSkUrj6jJhCMoSQPlCzRUgFxWEwqqoZHdNOER/nja2LQw==",
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-1.16.4.tgz",
+      "integrity": "sha512-kt+elLN8NAPQDGNaAGymCjsaLw0MjuMpDTXR1rH4EHnyarnmzQIsI6J5NGyGPvIKiPt+wNrQ2amyRc1JNjBAGQ==",
       "dependencies": {
         "@eyevinn/m3u8": "^0.4.0",
         "debug": "^4.1.1",
-        "node-fetch": "^2.6.1"
+        "node-fetch": "2.6.2"
       }
     },
     "node_modules/@eyevinn/hls-vodtolive/node_modules/debug": {
@@ -1238,9 +1238,9 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==",
       "engines": {
         "node": "4.x || >=6.0.0"
       }
@@ -2024,13 +2024,13 @@
       }
     },
     "@eyevinn/hls-vodtolive": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-1.16.2.tgz",
-      "integrity": "sha512-RBHlfz5g/mklRJZV0XjviOwo+EbCV0Z3maonQwkXWqSkUrj6jJhCMoSQPlCzRUgFxWEwqqoZHdNOER/nja2LQw==",
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-1.16.4.tgz",
+      "integrity": "sha512-kt+elLN8NAPQDGNaAGymCjsaLw0MjuMpDTXR1rH4EHnyarnmzQIsI6J5NGyGPvIKiPt+wNrQ2amyRc1JNjBAGQ==",
       "requires": {
         "@eyevinn/m3u8": "^0.4.0",
         "debug": "^4.1.1",
-        "node-fetch": "^2.6.1"
+        "node-fetch": "2.6.2"
       },
       "dependencies": {
         "debug": {
@@ -2929,9 +2929,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
+      "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA=="
     },
     "oauth-sign": {
       "version": "0.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eyevinn-channel-engine",
-  "version": "3.0.0-rc.2",
+  "version": "3.0.0-rc.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eyevinn-channel-engine",
-      "version": "3.0.0-rc.2",
+      "version": "3.0.0-rc.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@eyevinn/hls-repeat": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "dependencies": {
     "@eyevinn/hls-repeat": "^0.1.1",
     "@eyevinn/hls-truncate": "^0.1.0",
-    "@eyevinn/hls-vodtolive": "^1.16.2",
+    "@eyevinn/hls-vodtolive": "^1.16.4",
     "@eyevinn/m3u8": "^0.4.0",
     "abort-controller": "^3.0.0",
     "debug": "^3.2.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eyevinn-channel-engine",
-  "version": "3.0.0-rc.3",
+  "version": "3.0.0-rc.2",
   "description": "OTT TV Channel Engine",
   "main": "index.js",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -146,9 +146,8 @@ class StreamSwitchManager {
         title: "Live stream test",
         type: StreamType.LIVE,
         start_time: startOffset/2,
-        end_time: 60*endTime,
-        uri: "https://engine.cdn.consuo.tv/live/master.m3u8?channel=eyevinn",
-        //uri: "https://csm-e-telenorse-eb.tls1.yospace.com/csm/extlive/telenorseprd01,vc-clear.m3u8?yo.ac=true&yo.d.cp=true&forceAds=true&tv4.chId=61",
+        end_time: endTime,
+        uri: "https://cph-p2p-msl.akamaized.net/hls/live/2000341/test/master.m3u8",
       },
       {
         eventId: this.generateID(),
@@ -182,91 +181,3 @@ const engineOptions = {
 const engine = new ChannelEngine(refAssetManager, engineOptions);
 engine.start();
 engine.listen(process.env.PORT || 8000);
-
-/*{
-  "items": {
-    "PlaylistItem": [
-      {"attributes": {
-        "attributes":{}
-      },
-      "properties": {
-        "byteRange":null,
-        "daiPlacementOpportunity": null,
-        "date":null,
-        "discontinuity":null,
-        "duration":9,
-        "title":"",
-        "uri":"https://maitv-vod.lab.eyevinn.technology/tvplus-ad-megha.mov/2000/2000-00004.ts"
-      }
-    },
-    {
-      "attributes":
-    {
-      "attributes":{}
-    },
-    "properties":{
-      "byteRange":null,
-      "daiPlacementOpportunity":null,
-      "date":null,"discontinuity":null,
-      "duration":6,
-      "title":"",
-      "uri":"https://maitv-vod.lab.eyevinn.technology/tvplus-ad-megha.mov/2000/2000-00005.ts"
-    }},
-    {"attributes":{
-      "attributes":{}
-    },"properties":{
-      "byteRange":null,
-      "daiPlacementOpportunity":null,
-      "date":null,
-      "discontinuity":null,
-      "duration":9,
-      "title":""
-      ,"uri":"https://maitv-vod.lab.eyevinn.technology/tvplus-ad-megha.mov/2000/2000-00006.ts"
-    }
-  },
-  {"attributes":{
-    "attributes":{}
-  },
-  "properties":{
-    "byteRange":null,
-    "daiPlacementOpportunity":null,
-    "date":null,
-    "discontinuity":null,
-    "duration":1.867,
-    "title":"",
-    "uri":"https://maitv-vod.lab.eyevinn.technology/tvplus-ad-megha.mov/2000/2000-00007.ts"
-  }
-},
-{
-  "attributes":{
-    "attributes":{
-      "cueout":15
-    }
-  },
-  "properties":{
-    "byteRange":null,
-    "daiPlacementOpportunity":null,
-    "date":null,
-    "discontinuity":true,
-    "duration":10.88,
-    "title":"","uri":"https://maitv-vod.lab.eyevinn.technology/ads/6cd7d768-e214-4ebc-9f14-7ed89710115e.mp4/2000/2000-00000.ts"
-  }
-},
-{
-  "attributes":{
-    "attributes":{
-      "cuein":true
-    }
-  },
-  "properties":{
-    "byteRange":null,
-    "daiPlacementOpportunity":null,
-    "date":null,
-    "discontinuity":null,
-    "duration":4.24,
-    "title":"",
-    "uri":"https://maitv-vod.lab.eyevinn.technology/ads/6cd7d768-e214-4ebc-9f14-7ed89710115e.mp4/2000/2000-00001.ts"
-  }
-}
-  }
-}*/

--- a/server.js
+++ b/server.js
@@ -61,11 +61,6 @@ class RefAssetManager {
           uri: vod.uri,
           breaks: [
             {
-              pos: 0,
-              duration: 15 * 1000,
-              url: "https://maitv-vod.lab.eyevinn.technology/ads/6cd7d768_e214_4ebc_9f14_7ed89710115e_mp4/master.m3u8"
-            },
-            {
               pos: 100,
               duration: 15 * 1000,
               url: "https://maitv-vod.lab.eyevinn.technology/ads/6cd7d768_e214_4ebc_9f14_7ed89710115e_mp4/master.m3u8"
@@ -145,7 +140,7 @@ class StreamSwitchManager {
         assetId: this.generateID(),
         title: "Live stream test",
         type: StreamType.LIVE,
-        start_time: startOffset/2,
+        start_time: startOffset,
         end_time: endTime,
         uri: "https://cph-p2p-msl.akamaized.net/hls/live/2000341/test/master.m3u8",
       },

--- a/server.js
+++ b/server.js
@@ -59,7 +59,13 @@ class RefAssetManager {
         }
         const payload = {
           uri: vod.uri,
-          breaks: []
+          breaks: [
+            {
+              pos: 0,
+              duration: 105 * 1000,
+              url: "https://maitv-vod.lab.eyevinn.technology/VINN.mp4/master.m3u8"
+            }
+          ],
         };
         const buff = Buffer.from(JSON.stringify(payload));
         const encodedPayload = buff.toString("base64");
@@ -123,7 +129,7 @@ class StreamSwitchManager {
     const tsNow = Date.now();
     const streamDuration = 60 * 1000;
     const startOffset = tsNow + streamDuration;
-    const endTime = startOffset + 3*streamDuration;
+    const endTime = startOffset + streamDuration;
     // Break in with live and scheduled VOD content after 60 seconds of VOD2Live the first time Channel Engine starts
     // Required: "assetId", "start_time", "end_time", "uri", "duration"
     // "duration" is only required for StreamType.VOD

--- a/server.js
+++ b/server.js
@@ -62,10 +62,15 @@ class RefAssetManager {
           breaks: [
             {
               pos: 0,
-              duration: 105 * 1000,
-              url: "https://maitv-vod.lab.eyevinn.technology/VINN.mp4/master.m3u8"
+              duration: 15 * 1000,
+              url: "https://maitv-vod.lab.eyevinn.technology/ads/6cd7d768_e214_4ebc_9f14_7ed89710115e_mp4/master.m3u8"
+            },
+            {
+              pos: 100,
+              duration: 15 * 1000,
+              url: "https://maitv-vod.lab.eyevinn.technology/ads/6cd7d768_e214_4ebc_9f14_7ed89710115e_mp4/master.m3u8"
             }
-          ],
+          ]
         };
         const buff = Buffer.from(JSON.stringify(payload));
         const encodedPayload = buff.toString("base64");
@@ -140,9 +145,10 @@ class StreamSwitchManager {
         assetId: this.generateID(),
         title: "Live stream test",
         type: StreamType.LIVE,
-        start_time: startOffset,
-        end_time: endTime,
-        uri: "https://cph-p2p-msl.akamaized.net/hls/live/2000341/test/master.m3u8",
+        start_time: startOffset/2,
+        end_time: 60*endTime,
+        uri: "https://engine.cdn.consuo.tv/live/master.m3u8?channel=eyevinn",
+        //uri: "https://csm-e-telenorse-eb.tls1.yospace.com/csm/extlive/telenorseprd01,vc-clear.m3u8?yo.ac=true&yo.d.cp=true&forceAds=true&tv4.chId=61",
       },
       {
         eventId: this.generateID(),
@@ -176,3 +182,91 @@ const engineOptions = {
 const engine = new ChannelEngine(refAssetManager, engineOptions);
 engine.start();
 engine.listen(process.env.PORT || 8000);
+
+/*{
+  "items": {
+    "PlaylistItem": [
+      {"attributes": {
+        "attributes":{}
+      },
+      "properties": {
+        "byteRange":null,
+        "daiPlacementOpportunity": null,
+        "date":null,
+        "discontinuity":null,
+        "duration":9,
+        "title":"",
+        "uri":"https://maitv-vod.lab.eyevinn.technology/tvplus-ad-megha.mov/2000/2000-00004.ts"
+      }
+    },
+    {
+      "attributes":
+    {
+      "attributes":{}
+    },
+    "properties":{
+      "byteRange":null,
+      "daiPlacementOpportunity":null,
+      "date":null,"discontinuity":null,
+      "duration":6,
+      "title":"",
+      "uri":"https://maitv-vod.lab.eyevinn.technology/tvplus-ad-megha.mov/2000/2000-00005.ts"
+    }},
+    {"attributes":{
+      "attributes":{}
+    },"properties":{
+      "byteRange":null,
+      "daiPlacementOpportunity":null,
+      "date":null,
+      "discontinuity":null,
+      "duration":9,
+      "title":""
+      ,"uri":"https://maitv-vod.lab.eyevinn.technology/tvplus-ad-megha.mov/2000/2000-00006.ts"
+    }
+  },
+  {"attributes":{
+    "attributes":{}
+  },
+  "properties":{
+    "byteRange":null,
+    "daiPlacementOpportunity":null,
+    "date":null,
+    "discontinuity":null,
+    "duration":1.867,
+    "title":"",
+    "uri":"https://maitv-vod.lab.eyevinn.technology/tvplus-ad-megha.mov/2000/2000-00007.ts"
+  }
+},
+{
+  "attributes":{
+    "attributes":{
+      "cueout":15
+    }
+  },
+  "properties":{
+    "byteRange":null,
+    "daiPlacementOpportunity":null,
+    "date":null,
+    "discontinuity":true,
+    "duration":10.88,
+    "title":"","uri":"https://maitv-vod.lab.eyevinn.technology/ads/6cd7d768-e214-4ebc-9f14-7ed89710115e.mp4/2000/2000-00000.ts"
+  }
+},
+{
+  "attributes":{
+    "attributes":{
+      "cuein":true
+    }
+  },
+  "properties":{
+    "byteRange":null,
+    "daiPlacementOpportunity":null,
+    "date":null,
+    "discontinuity":null,
+    "duration":4.24,
+    "title":"",
+    "uri":"https://maitv-vod.lab.eyevinn.technology/ads/6cd7d768-e214-4ebc-9f14-7ed89710115e.mp4/2000/2000-00001.ts"
+  }
+}
+  }
+}*/


### PR DESCRIPTION
Fix: #99 

This PR adds support for cue tags when transitioning from V2L->Live. 

If an `EXT-X-CUE-OUT` (with a duration) is included in the VOD manifest it will be preserved in the transition manifest.