### PR TITLE
check if live session for current channel is available before stopping live playhead

### DIFF
--- a/engine/server.js
+++ b/engine/server.js
@@ -252,9 +252,13 @@ class ChannelEngine {
       debug(`Removing channel with ID ${channelId}`);
       clearInterval(this.monitorTimer[channelId]);
       await sessions[channelId].stopPlayheadAsync();
-      await sessionsLive[channelId].stopPlayheadAsync();
+      if (sessionsLive[channelId]) {
+        await sessionsLive[channelId].stopPlayheadAsync();
+      } else {
+        debug(`Cannot remove live session of channel that does not exist ${channelId}`);
+        delete sessionsLive[channelId];
+      }
       delete sessions[channelId];
-      delete sessionsLive[channelId];
       delete sessionSwitchers[channelId];
       delete switcherStatus[channelId];
     };

--- a/engine/server.js
+++ b/engine/server.js
@@ -254,9 +254,9 @@ class ChannelEngine {
       await sessions[channelId].stopPlayheadAsync();
       if (sessionsLive[channelId]) {
         await sessionsLive[channelId].stopPlayheadAsync();
+        delete sessionsLive[channelId];
       } else {
         debug(`Cannot remove live session of channel that does not exist ${channelId}`);
-        delete sessionsLive[channelId];
       }
       delete sessions[channelId];
       delete sessionSwitchers[channelId];

--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -373,6 +373,9 @@ class SessionLive {
 
   // Generate manifest to give to client
   async getCurrentMediaManifestAsync(bw) {
+    if (!this.sessionLiveState) {
+      throw new Error('SessionLive not ready');
+    }
     if (bw === null) {
       debug(`[${this.sessionId}]: No bandwidth provided`);
       return null;
@@ -1012,7 +1015,7 @@ class SessionLive {
         this.liveSegQueue[liveTargetBandwidth].push({ cue: { scteData: attributes["scteData"] } });
         this.liveSegsForFollowers[liveTargetBandwidth].push({ cue: { scteData: attributes["scteData"] } });
       }
-      if ("scteData" in attributes) {
+      if ("assetData" in attributes) {
         this.liveSegQueue[liveTargetBandwidth].push({ cue: { assetData: attributes["assetData"] } });
         this.liveSegsForFollowers[liveTargetBandwidth].push({ cue: { assetData: attributes["assetData"] } });
       }


### PR DESCRIPTION
This PR fixes a bug where if a channel that didn't exist was trying to be reached the `stopPlayheadAsync()` would be called on a nonexistent live session which would cause the Channel Engine to crash. 

Also fixes a typo in Session Live related to ad markers. 