### PR TITLE
fix playback issues for live content in safari and add support for daterange tags

### DIFF
--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -10,7 +10,6 @@ const { AbortController } = require("abort-controller");
 const timer = (ms) => new Promise((res) => setTimeout(res, ms));
 const daterangeAttribute = (key, attr) => {
   if (key === "planned-duration" || key === "duration") {
-    console.log("Attribute is: " + attr + "Parsed gives us: " + parseFloat(attr));
     return key.toUpperCase() + "=" + `${attr.toFixed(3)}`;
   } else {
     return key.toUpperCase() + "=" + `"${attr}"`;


### PR DESCRIPTION
Fixes: #103 

This PR fixes the playback issues in safari and adds support for `#EXT-X-DATERANGE` tags in live content. 
The playback issues was because the `#EXT-X-TARGETDURATION` could be set to a float.