### PR TITLE
chore: added 3 new get functions in server.js

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -11,6 +11,7 @@ const { PlayheadState } = require('./playhead_state.js');
 
 const { applyFilter, cloudWatchLog, m3u8Header, logerror } = require('./util.js');
 const ChaosMonkey = require('./chaos_monkey.js');
+const { Console } = require('console');
 
 const AVERAGE_SEGMENT_DURATION = 3000;
 const DEFAULT_PLAYHEAD_DIFF_THRESHOLD = 1000;
@@ -683,6 +684,21 @@ class Session {
     });
     this._sessionState.set("tsLastRequestMaster", Date.now());
     return m3u8;
+  }
+
+  async getAudioGroupsAndLangs() {
+    const currentVod = await this._sessionState.getCurrentVod();
+    if (!currentVod) {
+      throw new Error('Session not ready');
+    }
+    const audioGroupIds = currentVod.getAudioGroups();
+    let allAudioGroupsAndTheirLanguages = {};
+    audioGroupIds.forEach((groupId) => {
+      allAudioGroupsAndTheirLanguages[groupId] =
+        currentVod.getAudioLangsForAudioGroup(groupId);
+    });
+    
+    return allAudioGroupsAndTheirLanguages;
   }
 
   consumeEvent() {

--- a/engine/session.js
+++ b/engine/session.js
@@ -11,7 +11,6 @@ const { PlayheadState } = require('./playhead_state.js');
 
 const { applyFilter, cloudWatchLog, m3u8Header, logerror } = require('./util.js');
 const ChaosMonkey = require('./chaos_monkey.js');
-const { Console } = require('console');
 
 const AVERAGE_SEGMENT_DURATION = 3000;
 const DEFAULT_PLAYHEAD_DIFF_THRESHOLD = 1000;


### PR DESCRIPTION
For #115 

This PR adds 3 new functions, they can be used to return all types of manifest that the channel engine can serve to a client.
It is a bit tedious to test (run in demux mode and try with different vods with a variety of audio groups and languages). 
I believe I have tested all basic cases and it works.

Specs for these can be written later I suppose

Example engine.getMasterManifest(chId) return string:
```
#EXTM3U
#EXT-X-VERSION:4
#EXT-X-STREAM-INF:BANDWIDTH=6134000,RESOLUTION=1024x458,CODECS="avc1.4d001f,mp4a.40.2"
master6134000.m3u8;session=1
```
Example engine.getMediaManifests(chId) return object:
```
{
    1313000: "#EXTM3U . . .",
    1212000: "#EXTM3U . . .",
     789000: "#EXTM3U . . ."
}
```

Example engine.getAudioManifests(chId) return object:
```
{
  'group-A': {
               'lang-A': "EXTM3U . . .",
               'lang-B': "EXTM3U . . .",
             },
  'group-B': {
               'lang-A': "EXTM3U . . .",
               'lang-B': "EXTM3U . . .",
             },
}
```