### PR TITLE
Fix/reset endpoint livemix and ha v2

### DIFF
--- a/engine/server.js
+++ b/engine/server.js
@@ -200,7 +200,13 @@ class ChannelEngine {
         debug(`Tried to switch stream on a non-existing channel=[${channel}]. Switching Ignored!)`);
       }
     }
-    await Promise.all(channels.map(channel => getSwitchStatusAndPerformSwitch(channel)));
+    try {
+      await Promise.all(channels.map(channel => getSwitchStatusAndPerformSwitch(channel)));
+    } catch (err) {
+      debug('Problem occured when updating streamSwitchers');
+      throw new Error (err);
+    }
+
   }
 
   async updateChannelsAsync(channelMgr, options) {
@@ -663,8 +669,10 @@ class ChannelEngine {
     let sessionResets = [];
     for (const sessionId of Object.keys(sessions)) {
       const session = sessions[sessionId];
-      if (session) {
-        await session.resetAsync();
+      const sessionLive = sessionsLive[sessionId];
+      if (session && sessionLive) {
+        switcherStatus[sessionId] = false;
+        await session.resetAsync(); 
         sessionResets.push(sessionId);
       } else {
         const err = new errs.NotFoundError('Invalid session');

--- a/engine/server.js
+++ b/engine/server.js
@@ -671,7 +671,6 @@ class ChannelEngine {
       const session = sessions[sessionId];
       const sessionLive = sessionsLive[sessionId];
       if (session && sessionLive) {
-        switcherStatus[sessionId] = false;
         await session.resetAsync(); 
         sessionResets.push(sessionId);
       } else {

--- a/engine/server.js
+++ b/engine/server.js
@@ -188,6 +188,7 @@ class ChannelEngine {
         let status = null;
         try {
           status = await switcher.streamSwitcher(sessions[channel], sessionsLive[channel]);
+          debug(`[${channel}]: streamSwitcher returned switchstatus=${status}`);
           if (status === undefined) {
             debug(`[WARNING]: switcherStatus->${status}. Setting value to previous status->${prevStatus}`);
             status = prevStatus;
@@ -527,7 +528,7 @@ class ChannelEngine {
           await timer(500);
         }
         let body = null;
-        debug(`switcherStatus[req.params[1]]=[${switcherStatus[req.params[1]]}]`);
+        debug(`switcherStatus[${req.params[1]}]=[${switcherStatus[req.params[1]]}]`);
         if (switcherStatus[req.params[1]]) {
           debug(`[${req.params[1]}]: Responding with Live-stream manifest`);
           body = await sessionLive.getCurrentMediaManifestAsync(req.params[0]);

--- a/engine/session.js
+++ b/engine/session.js
@@ -362,6 +362,7 @@ class Session {
       throw new Error('Session not ready');
     }
     const playheadState = await this._playheadState.getValues(["mediaSeq", "vodMediaSeqVideo"]);
+    const discSeqOffset = await this._sessionState.get("discSeq");
     if (playheadState.vodMediaSeqVideo === 0) {
       const isLeader = await this._sessionStateStore.isLeader(this._instanceId);
       if (!isLeader) {
@@ -372,7 +373,7 @@ class Session {
     const currentVod = await this._sessionState.getCurrentVod();
     if (currentVod) {
       try {
-        const discSeqCount = currentVod.getLastUsedDiscSeq();
+        const discSeqCount = discSeqOffset + currentVod.discontinuities[playheadState.vodMediaSeqVideo];
         debug(`[${this._sessionId}]: MediaSeq: (${(playheadState.mediaSeq + playheadState.vodMediaSeqVideo)}) and DiscSeq: (${discSeqCount}) requested `);
         return {
           'mediaSeq': (playheadState.mediaSeq + playheadState.vodMediaSeqVideo),

--- a/engine/session.js
+++ b/engine/session.js
@@ -45,6 +45,7 @@ class Session {
     this.diffCompensation = null;
     this._currentAssetId = null;
 
+
     if (config) {
       if (config.sessionId) {
         this._sessionId = config.sessionId;
@@ -778,6 +779,7 @@ class Session {
         await this._sessionState.clearCurrentVodCache();
       }
     }
+
     switch (sessionState.state) {
       case SessionState.VOD_INIT:
       case SessionState.VOD_INIT_BY_ID:
@@ -887,6 +889,7 @@ class Session {
             debug(`[${this._sessionId}]: First mediasequence in VOD and I am not the leader so invalidate current VOD cache and fetch the new one from the leader`);
             await this._sessionState.clearCurrentVodCache();
           }
+          this.waitingForNextVod = true;
         }
         return;
       case SessionState.VOD_NEXT_INIT:
@@ -970,6 +973,7 @@ class Session {
             return;
           } else {
             debug(`[${this._sessionId}]: not a leader so will go directly to state VOD_NEXT_INITIATING`);
+            this.waitingForNextVod = true;
             sessionState.state = await this._sessionState.set("state", SessionState.VOD_NEXT_INITIATING);
             sessionState.currentVod = await this._sessionState.getCurrentVod();
           }

--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -289,6 +289,13 @@ class SessionLive {
     // Don't use what Session gave you. Use the Leaders number if it's available
     const isLeader = await this.sessionLiveStateStore.isLeader(this.instanceId);
     let liveCounts = await this.sessionLiveState.get("firstCounts");
+    if (liveCounts === null) {
+      liveCounts = {
+        liveSourceMseqCount: null,
+        mediaSeqCount: null,
+        discSeqCount: null,
+      };
+    }
     if (isLeader) {
       liveCounts.discSeqCount = this.discSeqCount;
       await this.sessionLiveState.set("firstCounts", liveCounts);

--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -136,7 +136,7 @@ class SessionLive {
         if (!this.masterManifestUri) {
           await timer(3000);
           continue;
-        }
+        } 
         if (this.playheadState === PlayheadState.STOPPED) {
           debug(`[${this.sessionId}]: Playhead has Stopped, clearing local session and store.`);
           this.waitForPlayhead = false;
@@ -824,7 +824,7 @@ class SessionLive {
       }
 
       // [LASTLY]: LEADER does this for respawned-FOLLOWERS' sake.
-      if (this.firstTime) {
+      if (this.firstTime && this.allowedToSet) {
         // Buy some time for followers (NOT Respawned) to fetch their own L.S m3u8.
         await timer(1000); // maybe remove
         const firstCounts = {
@@ -1048,6 +1048,7 @@ class SessionLive {
         this.liveSegQueue[liveTargetBandwidth].map((seg) => {if (seg.uri) { segCount++ }});
         debug(`[${this.sessionId}]: size of queue=${segCount}_targetNumseg=${this.targetNumSeg}`);
         if (segCount > this.targetNumSeg) {
+          debug(`[${this.sessionId}]: liveTargetBandwidth=${liveTargetBandwidth}_seg=${JSON.stringify(seg,null,2)}`);
           seg = this.liveSegQueue[liveTargetBandwidth].shift();
           if (seg) {
             if (seg.discontinuity) {
@@ -1055,6 +1056,7 @@ class SessionLive {
               amountRemovedDiscSeqs++;
             }
           }
+          debug(`[${this.sessionId}]: After Shifting -> size of queue=${segCount}_targetNumseg=${this.targetNumSeg}`);
         }
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eyevinn-channel-engine",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eyevinn-channel-engine",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@eyevinn/hls-repeat": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eyevinn-channel-engine",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eyevinn-channel-engine",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@eyevinn/hls-repeat": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eyevinn-channel-engine",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "OTT TV Channel Engine",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eyevinn-channel-engine",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "OTT TV Channel Engine",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
clear by vod asset id instead, to avoid the chances of double clearing and an extra currentVod read.
More accurate way to determine if the asset in store is different. But comes at the cost of setting and getting assetId. 