### PR TITLE
Fix: do not update prev mseq if pushAmount is negative

### DIFF
--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -951,7 +951,9 @@ class SessionLive {
         //   this.targetNumSeg = m3u.items.PlaylistItem.length;
         // }
 
-        this.lastRequestedMediaSeqRaw = m3u.get("mediaSequence");
+        if (this.pushAmount >= 0) {
+          this.lastRequestedMediaSeqRaw = m3u.get("mediaSequence"); 
+        } 
         this.targetDuration = m3u.get("targetDuration");
         let amountRemovedDiscSeqs = 0;
         let startIdx = m3u.items.PlaylistItem.length - this.pushAmount;


### PR DESCRIPTION
PR fixes #138 

By not updating `lastRequestedMediaSeqRaw` when pushAmount is negative, the issue of appending duplicate segments is avoided.