### PR TITLE
fix: replace all relavant playheadState values

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -395,7 +395,7 @@ class Session {
     if (!this._sessionState) {
       throw new Error('Session not ready');
     }
-    const sessionState = await this._sessionState.getValues(["discSeq", "vodMediaSeqVideo"]);
+    const sessionState = await this._sessionState.getValues(["mediaSeq", "discSeq", "vodMediaSeqVideo"]);
     const playheadState = await this._playheadState.getValues(["mediaSeq", "vodMediaSeqVideo"]);
 
     /*
@@ -405,6 +405,7 @@ class Session {
     */
     if (playheadState.vodMediaSeqVideo > sessionState.vodMediaSeqVideo) {
       playheadState.vodMediaSeqVideo = sessionState.vodMediaSeqVideo;
+      playheadState.mediaSeq = sessionState.mediaSeq;
     }
 
     if (playheadState.vodMediaSeqVideo === 0 || this.waitingForNextVod) { 

--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -781,7 +781,8 @@ class SessionLive {
       await allSettled(pushPromises);
 
       // UPDATE COUNTS, & Shift Segments in vodSegments and liveSegQueue if needed.
-      const newTotalDuration = this._incrementAndShift("LEADER");
+      const leaderORFollower = isLeader ? "LEADER" : "NEW FOLLOWER";
+      const newTotalDuration = this._incrementAndShift(leaderORFollower);
       if (newTotalDuration) {
         debug(`[${this.sessionId}]: New Adjusted Playlist Duration=${newTotalDuration}s`);
       }

--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -645,7 +645,9 @@ class SessionLive {
         if (Object.keys(this.liveSegQueue).length > 0) {
           const firstBw = Object.keys(this.liveSegQueue)[0];
           const lastIdx = this.liveSegQueue[firstBw].length - 1;
-          retryDelayMs = this.liveSegQueue[firstBw][lastIdx].duration * 1000 * 0.25;
+          if (this.liveSegQueue[firstBw][lastIdx].duration) {
+            retryDelayMs = this.liveSegQueue[firstBw][lastIdx].duration * 1000 * 0.25;
+          }
         }
         // Wait a little before trying again
         debug(`[${this.sessionId}]: ALERT! Live Source Data NOT in sync! Will try again after ${retryDelayMs}ms`);


### PR DESCRIPTION
PR completes the fix for an edge-case where the client may request a manifest right before playheadState media seq values are updated but right after a new currentVod is set, and the currentVod cache has been cleared. Resulting in returning an unexpected manifest. This is a temporary issue as the cache and playheadState values will eventually be correct, but it is still not a desired outcome to have the channel-engine return any bad manifest.

We could just NOT clear the cache, and ensure that the outdated playheadState values match the cached currentVod...

...but the main reason for clearing the cache sooner than before was to handle _another_ edge case where the media sequence from a follower nodes perspective goes from ex, 14/15 -> 1/20, where media sequence 0 was essentially skipped. 

e.i. the cache clearing condition 
```
playheadState.vodMediaSeqVideo === 0
```
in `async getCurrentMediaManifestAsync(bw, playbackSessionId)` would not have been triggered.