### PR TITLE
Fix: Rework previous issue fix

### DIFF
--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -247,7 +247,7 @@ class SessionLive {
       if (!this.vodSegments[bw]) {
         this.vodSegments[bw] = [];
       }
-
+      
       if (segments[bw][0].discontinuity) {
         segments[bw].shift();
       }
@@ -644,6 +644,9 @@ class SessionLive {
         // Wait a little before trying again
         debug(`[${this.sessionId}]: ALERT! Live Source Data NOT in sync! Will try again after ${retryDelayMs}ms`);
         await timer(retryDelayMs);
+        if (isLeader) {
+          this.timerCompensation = false;
+        }
         continue;
       }
 


### PR DESCRIPTION
This PR will rework some changes made in the last PR.

- A Leader-node MUST skip playhead tick time compensation. While a Follower should skip the time compensation.
- The setting playheadState values to the newest sessionState values assumed that the sessionsState values were all actually already updated, but that is not always the case. Some might be updated at the time of the request but not necessarily all. 
So changing it back to how it was before.  Only this time, a Follower node will be sure to clear the vod cache as soon as its playheadState mseq is 0 or 1. 
That way, hopefully, when the client requests a manifest, the function `getCurrentMediaManifestAsync(.)` should no longer be creating a faulty Media Sequence count in the generated manifest.

