### PR TITLE
Fix: Remove the need for ampersands in manifest filter query 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ Then point your HLS video player to `http://localhost:8000/channels/1/master.m3u
 
 ## Master manifest filtering
 
-The engine supports a very simplistic and basic filtering of media playlists included in the master manifest. Currently supports to filter on video bandwidth and video height. To specify a filter provide the query parameter `filter` when loading the master manifest, e.g. `(type=="video"&&height>200)&&(type=="video"&&height<400)`. This needs to be URL encoded resulting in the following URL: `http://localhost:8000/channels/1/master.m3u8?filter=%28type%3D%3D%22video%22%26%26height%3E200%29%26%26%28type%3D%3D%22video%22%26%26height%3C400%29`
+The engine supports a very simplistic and basic filtering of media playlists included in the master manifest. Currently supports to filter on video bandwidth and video height. To specify a filter provide the query parameter `filter` when loading the master manifest, e.g. `(type=="video"ANDheight>200)AND(type=="video"ANDheight<400)`. This needs to be URL encoded resulting in the following URL: `http://localhost:8000/channels/1/master.m3u8?filter=%28type%3D%3D%22video%22ANDheight%3E200%29AND%28type%3D%3D%22video%22ANDheight%3C400%29`.
+
+To filter by video bandwidth use the `systemBitrate` keyword in the query, e.g. `(type=="video"ANDsystemBitrate>2121000)AND(type=="video"ANDsystemBitrate<6161000)`.
+
+You can also combine the filter conditions, e.g. `(type=="video"ANDheight>240)AND(type=="video"ANDsystemBitrate<4141000)`
 
 ## API
 

--- a/engine/util.js
+++ b/engine/util.js
@@ -1,9 +1,13 @@
-const { version } = require('../package.json');
+const { version } = require("../package.json");
 
 const filterQueryParser = (filterQuery) => {
   const conditions = filterQuery.match(/\(([^\(\)]*?)\)/g);
 
   let filter = {};
+  
+  if (!conditions) {
+    return filter;
+  }
   conditions.map((c) => {
     const m = c.match(/\(type=="(.*?)"(AND|\|\|)(.*?)(<|>)(.*)\)/);
     if (m) {
@@ -92,27 +96,25 @@ const ItemIsEmpty = (obj) => {
 const cloudWatchLog = (silent, type, logEntry) => {
   if (!silent) {
     logEntry.type = type;
-    logEntry.time = (new Date()).toISOString();
+    logEntry.time = new Date().toISOString();
     console.log(JSON.stringify(logEntry));
   }
 };
 
 const m3u8Header = (instanceId) => {
   let m3u8 = "";
-  m3u8 += `## Created with Eyevinn Channel Engine library (version=${version}${instanceId ? "<" + instanceId + ">" : "" })\n`;
+  m3u8 += `## Created with Eyevinn Channel Engine library (version=${version}${instanceId ? "<" + instanceId + ">" : ""})\n`;
   m3u8 += "##    https://www.npmjs.com/package/eyevinn-channel-engine\n";
   return m3u8;
 };
 
 const toHHMMSS = (secs) => {
-  var sec_num = parseInt(secs, 10)
-  var hours   = Math.floor(sec_num / 3600)
-  var minutes = Math.floor(sec_num / 60) % 60
-  var seconds = sec_num % 60
+  var sec_num = parseInt(secs, 10);
+  var hours = Math.floor(sec_num / 3600);
+  var minutes = Math.floor(sec_num / 60) % 60;
+  var seconds = sec_num % 60;
 
-  return [hours,minutes,seconds]
-      .map(v => v < 10 ? "0" + v : v)
-      .join(":")
+  return [hours, minutes, seconds].map((v) => (v < 10 ? "0" + v : v)).join(":");
 };
 
 const logerror = (sessionId, err) => {
@@ -126,5 +128,5 @@ module.exports = {
   cloudWatchLog,
   m3u8Header,
   toHHMMSS,
-  logerror
-}
+  logerror,
+};

--- a/spec/engine/util_spec.js
+++ b/spec/engine/util_spec.js
@@ -2,7 +2,7 @@ const { filterQueryParser, applyFilter } = require('../../engine/util.js');
 
 describe("Filter Query parser", () => {
   it("can handle systemBitrate low/high range", () => {
-    const filterQuery = `(type=="video"&&systemBitrate>100000)&&(type=="video"&&systemBitrate<800000)`;
+    const filterQuery = `(type=="video"ANDsystemBitrate>100000)AND(type=="video"ANDsystemBitrate<800000)`;
     const filter = filterQueryParser(filterQuery);
   
     expect(filter.video.systemBitrate.low).toEqual(100000);
@@ -10,11 +10,18 @@ describe("Filter Query parser", () => {
   });
 
   it("can handle resolution low/high range", () => {
-    const filterQuery = `(type=="video"&&height>600)&&(type=="video"&&height<1080)`;
+    const filterQuery = `(type=="video"ANDheight>600)AND(type=="video"ANDheight<1080)`;
     const filter = filterQueryParser(filterQuery);
 
     expect(filter.video.height.low).toEqual(600);
     expect(filter.video.height.high).toEqual(1080);  
+  });
+
+  it("can handle a faulty filter query", () => {
+    const filterQuery = `type=video&height=600&type=video&height=1080`;
+    const filter = filterQueryParser(filterQuery);
+
+    expect(filter).toEqual({}); 
   });
 });
 
@@ -60,10 +67,68 @@ describe("Profile filter", () => {
 
   
   it ("can filter out video tracks with height min 200 and max 400", () => {
-    const filterQuery = `(type=="video"&&height>200)&&(type=="video"&&height<400)`;
+    const filterQuery = `(type=="video"ANDheight>200)AND(type=="video"ANDheight<400)`;
     const filter = filterQueryParser(filterQuery);
 
     const filteredProfiles = applyFilter(PROFILE, filter);
     expect(filteredProfiles.length).toEqual(2);
   });
+
+  it ("can filter out video tracks with bitrate min 1414000 and max 3232000", () => {
+    const filterQuery = `(type=="video"ANDsystemBitrate>1414000)AND(type=="video"ANDsystemBitrate<3232000)`;
+    const filter = filterQueryParser(filterQuery);
+
+    const filteredProfiles = applyFilter(PROFILE, filter);
+    expect(filteredProfiles.length).toEqual(1);
+    expect(filteredProfiles[0].bw).toEqual(2323000);
+  });
+
+  it ("can filter out video tracks with bitrate min 1414000 and height min 300", () => {
+    const filterQuery = `(type=="video"ANDsystemBitrate>1414000)AND(type=="video"ANDheight>300)`;
+    const filter = filterQueryParser(filterQuery);
+
+    const filteredProfiles = applyFilter(PROFILE, filter);
+    expect(filteredProfiles.length).toEqual(1);
+    expect(filteredProfiles[0].bw).toEqual(6134000);
+  });
+
+  it ("can filter out video tracks with bitrate min 1414000", () => {
+    const filterQuery = `(type=="video"ANDsystemBitrate>1414000)`;
+    const filter = filterQueryParser(filterQuery);
+
+    const filteredProfiles = applyFilter(PROFILE, filter);
+    expect(filteredProfiles.length).toEqual(2);
+    expect(filteredProfiles[1].bw).toEqual(2323000);
+    expect(filteredProfiles[0].bw).toEqual(6134000);
+  });
+
+  it ("can filter out video tracks with bitrate max 1414000", () => {
+    const filterQuery = `(type=="video"ANDsystemBitrate<1414000)`;
+    const filter = filterQueryParser(filterQuery);
+
+    const filteredProfiles = applyFilter(PROFILE, filter);
+    expect(filteredProfiles.length).toEqual(1);
+    expect(filteredProfiles[0].bw).toEqual(1313000);
+  });
+
+  it ("can filter out video tracks with height min 250", () => {
+    const filterQuery = `(type=="video"ANDheight>250)`;
+    const filter = filterQueryParser(filterQuery);
+
+    const filteredProfiles = applyFilter(PROFILE, filter);
+    expect(filteredProfiles.length).toEqual(2);
+    expect(filteredProfiles[1].bw).toEqual(2323000);
+    expect(filteredProfiles[0].bw).toEqual(6134000);
+  });
+
+  it ("can filter out video tracks with height max 300", () => {
+    const filterQuery = `(type=="video"ANDheight<300)`;
+    const filter = filterQueryParser(filterQuery);
+
+    const filteredProfiles = applyFilter(PROFILE, filter);
+    expect(filteredProfiles.length).toEqual(2);
+    expect(filteredProfiles[1].bw).toEqual(1313000);
+    expect(filteredProfiles[0].bw).toEqual(2323000);
+  });
+
 });


### PR DESCRIPTION
PR to resolve #45 

The main issue seems to stem from the fact that the query string value needs ampersands (&&). 
I suggest would be to change the requirement for the '&&' chars and replacing it with 'AND'. 
This will yield more consistent query parsing in the restify server. 

I also went ahead and extended the `applyFilter(.)` utility function, so that it handles unsupported query formats,
and allows for also only setting a lower or upper condition boundary, as well as combining two types of conditions.