### PR TITLE
Fix: Bug on Switch to Live when instances have different V2L data

### DIFF
--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -483,8 +483,8 @@ class SessionLive {
     });
   }
 
-   // FOLLOWER only function
-   _updateLiveSegQueue() {
+  // FOLLOWER only function
+  _updateLiveSegQueue() {
     if (Object.keys(this.liveSegsForFollowers).length === 0) {
       debug(`[${this.sessionId}]: FOLLOWER: Error No Segments found at all.`);
     }

--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -693,13 +693,11 @@ class SessionLive {
 
         // Respawners never do this, only starter followers.
         // Edge Case: FOLLOWER transitioned from session with different segments from LEADER
-        const leaderStartedOnMseqCount = leadersFirstSeqCounts.mediaSeqCount;
-        const leaderStartedOnDseqCount = leadersFirstSeqCounts.discSeqCount;
-        if (leaderStartedOnDseqCount !== this.discSeqCount) {
-          this.discSeqCount = leaderStartedOnDseqCount;
+        if (leadersFirstSeqCounts.discSeqCount !== this.discSeqCount) {
+          this.discSeqCount = leadersFirstSeqCounts.discSeqCount;
         }
-        if (leaderStartedOnMseqCount !== this.mediaSeqCount) {
-          this.mediaSeqCount = leaderStartedOnMseqCount;
+        if (leadersFirstSeqCounts.mediaSeqCount !== this.mediaSeqCount) {
+          this.mediaSeqCount = leadersFirstSeqCounts.mediaSeqCount;
           debug(`[${this.sessionId}]: FOLLOWER transistioned with wrong V2L segments, updating counts to [${
             this.mediaSeqCount}][${this.discSeqCount}], and reading 'transitSegs' from store`);
           const transitSegs = await this.sessionLiveState.get("transitSegs");


### PR DESCRIPTION
This PR fixes 3 minor issues in regard to desync from an unusual/difficult Live Switch.

Two edge-case handlers got improved:

- Before, when a follower node switched with different V2L counts and segments, the mediaSeq and segments were updated to the correct ones, however, the discontinuity count was not updated. This was fixed.

-  When a follower node switches much later than a Leader node, due to being a respawned node, then it is to drop the live segment it has fetched and read the stored live segment instead. The IF conditions for this part needed some improvement as it could be triggered when it was not supposed to.

Also, added an extra check, to ensure the liveSegQueue only contains unique live segments.
The limitation we must have then is that a live source will never use the same segment (URI) multiple times in the same playlist.
If we want to allow a live source to behave like this then we will have to fix the issue some other way.