### PR TITLE
Fix: Desync from slow live source fetch, and more

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -446,7 +446,7 @@ class Session {
     const sessionState = await this._sessionState.getValues(["vodMediaSeqVideo", "discSeq"]);
     const playheadState = await this._playheadState.getValues(["mediaSeq", "vodMediaSeqVideo"]);
 
-    if (this.prevVodMediaSeq.video !== null) {
+    if (this.prevVodMediaSeq.video === null) {
       this.prevVodMediaSeq.video = playheadState.vodMediaSeqVideo;
     }
 
@@ -940,7 +940,7 @@ class Session {
           }
         } else {
           // Handle edge case where store has been reset, but leader has not cleared cache.
-          if (this.prevVodMediaSeq.video !== null) {
+          if (this.prevVodMediaSeq.video === null) {
             this.prevVodMediaSeq.video = sessionState.vodMediaSeqVideo;
           }
           if (this.prevVodMediaSeq.video < sessionState.vodMediaSeqVideo) {

--- a/engine/stream_switcher.js
+++ b/engine/stream_switcher.js
@@ -3,6 +3,7 @@ const crypto = require("crypto");
 const fetch = require("node-fetch");
 const { AbortController } = require("abort-controller");
 const { SessionState } = require('./session_state');
+const { timer } = require("./util")
 
 const SwitcherState = Object.freeze({
   V2L_TO_LIVE: 1,
@@ -151,6 +152,11 @@ class StreamSwitcher {
       );
       validURI = await this._validURI(scheduleObj.uri);
       tries++;
+      if (!validURI) {
+        const delayMs = tries * 500;
+        debug(`[${this.sessionId}]: Going to try validating Master URI again in ${delayMs}ms`);
+        await timer(delayMs);
+      }
     }
     if (!validURI) {
       debug(`[${this.sessionId}]: Unreachable URI: [${scheduleObj.uri}]`);

--- a/engine/util.js
+++ b/engine/util.js
@@ -122,6 +122,8 @@ const logerror = (sessionId, err) => {
   console.error(err);
 };
 
+const timer = ms => new Promise(res => setTimeout(res, ms));
+
 module.exports = {
   filterQueryParser,
   applyFilter,
@@ -129,4 +131,5 @@ module.exports = {
   m3u8Header,
   toHHMMSS,
   logerror,
+  timer
 };


### PR DESCRIPTION
PR fixes 4 bug issues
- stream_switcher.js -> Livestream validator now has a delay between retries.
- session-live.js -> playhead timer Interval now for a leader, has a limit on how low it can get.
Also, a follower now has a limit to how long it should wait for store reading retries.
- session.js -> Follower now properly takes over as leader when leader goes missing on `LIVE->V2L` switch, and sets the state to `VOD_RELOAD_INIT`.
- session.js -> Properly set starter value to this.prevVodMediaSeq.