### PR TITLE
Fix: Optimize vod cache clearing

### DIFF
--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -636,7 +636,9 @@ class SessionLive {
 
       // Handle if any promise got rejected
       if (manifestList.some((result) => result.status === "rejected")) {
-        debug(`[${this.sessionId}]: ALERT! Promises I: Failed, Rejection Found! Trying again...`);
+        FETCH_ATTEMPTS--;
+        debug(`[${this.sessionId}]: ALERT! Promises I: Failed, Rejection Found! Trying again in 1000ms...`);
+        await timer(1000)
         continue;
       }
 

--- a/engine/util.js
+++ b/engine/util.js
@@ -122,7 +122,33 @@ const logerror = (sessionId, err) => {
   console.error(err);
 };
 
-const timer = ms => new Promise(res => setTimeout(res, ms));
+const timer = (ms) => new Promise((res) => setTimeout(res, ms));
+
+class WaitTimeGenerator {
+  constructor(defaultIntervalMs, minValue) {
+    (this.timestamp = null), (this.prevWaitTime = null), (this.defaultIntervalMs = defaultIntervalMs || 3000), (this.minValue = minValue);
+  }
+  _getWaitTimeFromTimestamp() {
+    if (!this.timestamp) {
+      this.timestamp = new Date();
+    }
+    const sec = this.timestamp.getSeconds();
+    const defaultSec = this.defaultIntervalMs / 1000;
+    const d = parseInt(sec / defaultSec);
+    const waitSec = defaultSec * (d + 1) - sec;
+    return waitSec * 1000;
+  }
+  async getWaitTime(plannedTime) {
+    if (!this.timestamp || (this.prevWaitTime === this.minValue && plannedTime !== this.minValue)) {
+      this.timestamp = new Date();
+      const waitMs = this._getWaitTimeFromTimestamp();
+      this.prevWaitTime = waitMs;
+      return waitMs;
+    }
+    this.prevWaitTime = plannedTime;
+    return plannedTime;
+  }
+}
 
 module.exports = {
   filterQueryParser,
@@ -131,5 +157,6 @@ module.exports = {
   m3u8Header,
   toHHMMSS,
   logerror,
-  timer
+  timer,
+  WaitTimeGenerator,
 };


### PR DESCRIPTION
This PR cleans up redundant vod cache clearing checks. In earlier fixes, these cache clearers were needed to solve an issue.
However,  since we refactored the switchback-to-v2l logic a bit, these extra cache clearers became unnecessary.

I also added some boolean checks to have it so that the vod cache is only cleared once per case. 

eg. in the manifest request function `getCurrentMediaManifestAsync()`, if the current mseq=0|1 we would always clear the cache.
This would mean that the cache would be clear as often as manifest requests for that specific manifest sequence. There would be a window of ~(2*SegDuration) seconds, where we keep reading the vod from redis.