### PR TITLE
Feat: Add option for V2L mseqs to always contain new segments

### DIFF
--- a/engine/server.js
+++ b/engine/server.js
@@ -33,8 +33,12 @@ class ChannelEngine {
       this.adXchangeUri = options.adXchangeUri;
     }
     this.useDemuxedAudio = false;
-    if (options && options.useDemuxedAudio === true) {
+    if (options && options.useDemuxedAudio) {
       this.useDemuxedAudio = true;
+    }
+    this.alwaysNewSegments = false;
+    if (options && options.alwaysNewSegments) {
+      this.alwaysNewSegments = true;
     }
     if (options && options.defaultSlateUri) {
       this.defaultSlateUri = options.defaultSlateUri;
@@ -228,6 +232,7 @@ class ChannelEngine {
         sessionId: channel.id,
         averageSegmentDuration: channel.options && channel.options.averageSegmentDuration ? channel.options.averageSegmentDuration : this.streamerOpts.defaultAverageSegmentDuration,
         useDemuxedAudio: options.useDemuxedAudio,
+        alwaysNewSegments: options.alwaysNewSegments,
         playheadDiffThreshold: channel.options && channel.options.playheadDiffThreshold ? channel.options.playheadDiffThreshold : this.streamerOpts.defaultPlayheadDiffThreshold,
         maxTickInterval: channel.options && channel.options.maxTickInterval ? channel.options.maxTickInterval : this.streamerOpts.defaultMaxTickInterval,
         targetDurationPadding: channel.options && channel.options.targetDurationPadding ? channel.options.targetDurationPadding : this.streamerOpts.targetDurationPadding,
@@ -444,6 +449,7 @@ class ChannelEngine {
       options.adXchangeUri = this.adXchangeUri;
       options.averageSegmentDuration = this.streamerOpts.defaultAverageSegmentDuration;
       options.useDemuxedAudio = this.useDemuxedAudio;
+      options.alwaysNewSegments = this.alwaysNewSegments;
       options.playheadDiffThreshold = this.streamerOpts.defaultPlayheadDiffThreshold;
       options.maxTickInterval = this.streamerOpts.defaultMaxTickInterval;
       options.targetDurationPadding = this.streamerOpts.targetDurationPadding;

--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -542,7 +542,7 @@ class SessionLive {
         this.blockGenerateManifest = false;
       }
 
-      let attempts = 5;
+      let attempts = 10;
       //  CHECK AGAIN CASE 1: Store Empty
       while (!leadersMediaSeqRaw && attempts > 0) {
         const segDur = this._getAnyFirstSegmentDurationMs() || DEFAULT_PLAYHEAD_INTERVAL_MS;
@@ -565,7 +565,7 @@ class SessionLive {
         }
       }
 
-      attempts = 5;
+      attempts = 10;
       //  CHECK AGAIN CASE 2: Store Old
       while (leadersMediaSeqRaw <= this.lastRequestedMediaSeqRaw && attempts > 0) {
         const segDur = this._getAnyFirstSegmentDurationMs() || DEFAULT_PLAYHEAD_INTERVAL_MS;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@eyevinn/hls-repeat": "^0.1.1",
         "@eyevinn/hls-truncate": "^0.1.0",
-        "@eyevinn/hls-vodtolive": "^1.17.1",
+        "@eyevinn/hls-vodtolive": "^2.0.0",
         "@eyevinn/m3u8": "^0.4.1",
         "abort-controller": "^3.0.0",
         "debug": "^3.2.7",
@@ -80,11 +80,12 @@
       }
     },
     "node_modules/@eyevinn/hls-vodtolive": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-1.17.1.tgz",
-      "integrity": "sha512-T0dofpo46+HdCBGx/aewZszMQxniJUkinS86i41qwjI7tKfKHsfC/zs49QxgsXD/ZpjpxOcqHCMznJqY3Tf5Nw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.0.0.tgz",
+      "integrity": "sha512-rPgp8r3crGkKFg0a2vGK4pAXmZKmteyPkZgr+1X09jkVHsEZcGLcgDN05jTqbjfKcD73Fr3SWGQV/ounrRHFBA==",
       "dependencies": {
         "@eyevinn/m3u8": "^0.4.1",
+        "abort-controller": "^3.0.0",
         "debug": "^4.1.1",
         "node-fetch": "2.6.2"
       }
@@ -2156,11 +2157,12 @@
       }
     },
     "@eyevinn/hls-vodtolive": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-1.17.1.tgz",
-      "integrity": "sha512-T0dofpo46+HdCBGx/aewZszMQxniJUkinS86i41qwjI7tKfKHsfC/zs49QxgsXD/ZpjpxOcqHCMznJqY3Tf5Nw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.0.0.tgz",
+      "integrity": "sha512-rPgp8r3crGkKFg0a2vGK4pAXmZKmteyPkZgr+1X09jkVHsEZcGLcgDN05jTqbjfKcD73Fr3SWGQV/ounrRHFBA==",
       "requires": {
         "@eyevinn/m3u8": "^0.4.1",
+        "abort-controller": "^3.0.0",
         "debug": "^4.1.1",
         "node-fetch": "2.6.2"
       },

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@eyevinn/hls-repeat": "^0.1.1",
     "@eyevinn/hls-truncate": "^0.1.0",
-    "@eyevinn/hls-vodtolive": "^1.17.1",
+    "@eyevinn/hls-vodtolive": "^2.0.0",
     "@eyevinn/m3u8": "^0.4.1",
     "abort-controller": "^3.0.0",
     "debug": "^3.2.7",

--- a/server.js
+++ b/server.js
@@ -14,12 +14,12 @@ class RefAssetManager {
         {
           id: 1,
           title: "Tears of Steel",
-          uri: "https://maitv-vod.lab.eyevinn.technology/tearsofsteel_4k.mov/master.m3u8",
+          uri: "https://lab-live.cdn.eyevinn.technology/TEST_PDT_3/master.m3u8",
         },
         {
           id: 2,
           title: "VINN",
-          uri: "https://maitv-vod.lab.eyevinn.technology/VINN.mp4/master.m3u8",
+          uri: "https://lab-live.cdn.eyevinn.technology/SHORT60SEC/master.m3u8",
         },
       ],
     };
@@ -96,8 +96,9 @@ const engineOptions = {
     "https://maitv-vod.lab.eyevinn.technology/slate-consuo.mp4/master.m3u8",
   slateRepetitions: 10,
   redisUrl: process.env.REDIS_URL,
+  alwaysNewSegments: true
 };
 
 const engine = new ChannelEngine(refAssetManager, engineOptions);
 engine.start();
-engine.listen(process.env.port || 8000);
+engine.listen(process.env.PORT || 8000);

--- a/server.js
+++ b/server.js
@@ -14,12 +14,12 @@ class RefAssetManager {
         {
           id: 1,
           title: "Tears of Steel",
-          uri: "https://lab-live.cdn.eyevinn.technology/TEST_PDT_3/master.m3u8",
+          uri: "https://maitv-vod.lab.eyevinn.technology/tearsofsteel_4k.mov/master.m3u8",
         },
         {
           id: 2,
           title: "VINN",
-          uri: "https://lab-live.cdn.eyevinn.technology/SHORT60SEC/master.m3u8",
+          uri: "https://maitv-vod.lab.eyevinn.technology/VINN.mp4/master.m3u8",
         },
       ],
     };
@@ -96,7 +96,6 @@ const engineOptions = {
     "https://maitv-vod.lab.eyevinn.technology/slate-consuo.mp4/master.m3u8",
   slateRepetitions: 10,
   redisUrl: process.env.REDIS_URL,
-  alwaysNewSegments: true
 };
 
 const engine = new ChannelEngine(refAssetManager, engineOptions);

--- a/spec/engine/init_switching_spec.js
+++ b/spec/engine/init_switching_spec.js
@@ -413,12 +413,14 @@ describe("The initialize switching", () => {
       uri: "http://mock.mock.com/180000/seg12.ts",
     });
     expect(sessionCurrentSegs["1313000"][size - 1 - 2]).toEqual({
-      discontinuity: true,
-      cue: { in: true },
+      duration: 7.5,
+      timelinePosition: null,
+      uri: 'https://maitv-vod.lab.eyevinn.technology/tearsofsteel_4k.mov/600/600-00008.ts',
+      cue: null
     });
     expect(sessionCurrentSegs["1313000"][size - 1]).toEqual({
       duration: 7.5,
-      uri: "https://maitv-vod.lab.eyevinn.technology/tearsofsteel_4k.mov/600/600-00016.ts",
+      uri: "https://maitv-vod.lab.eyevinn.technology/tearsofsteel_4k.mov/600/600-00010.ts",
       timelinePosition: null,
       cue: null,
     });
@@ -469,7 +471,7 @@ describe("The initialize switching", () => {
     const size = sessionCurrentSegs["1313000"].length;
     expect(sessionCurrentSegs["1313000"][0]).toEqual({
       duration: 7.5,
-      uri: "https://maitv-vod.lab.eyevinn.technology/tearsofsteel_4k.mov/600/600-00011.ts",
+      uri: "https://maitv-vod.lab.eyevinn.technology/tearsofsteel_4k.mov/600/600-00012.ts",
       timelinePosition: null,
       cue: null,
     });
@@ -745,41 +747,41 @@ describe("The initialize switching", () => {
     const borderSegment = newVodSegments["1313000"][6];
 
     const expectedLastVODSegItem = {
-      duration: 7.2,
-      uri: "https://maitv-vod.lab.eyevinn.technology/MORBIUS_Trailer_2020.mp4/1000/1000-00008.ts",
-      timelinePosition: null,
-      cue: null,
+      discontinuity: true,
+      daterange: null
     }
     const expectedFirstV2LSegItem = {
-      duration: 10.846444,
-      uri: "https://maitv-vod.lab.eyevinn.technology/VINN.mp4/600/600-00000.ts",
+      duration: 7.2,
       timelinePosition: null,
       cue: null,
+      uri: 'https://maitv-vod.lab.eyevinn.technology/VINN.mp4/600/600-00001.ts'
     }
     const expectedSecondVODSegItem = {
       duration: 7.5075,
-      uri: "https://maitv-vod.lab.eyevinn.technology/BECKY_Trailer_2020.mp4/600/600-00001.ts",
+      uri: "https://maitv-vod.lab.eyevinn.technology/BECKY_Trailer_2020.mp4/1000/1000-00001.ts",
       timelinePosition: null,
       cue: null,
     }
 
     expect(newVodSegments["1313000"][0]).toEqual(expectedLastVODSegItem);
     expect(newVodSegments["1313000"][1]).toEqual({
-      discontinuity: true,
-      daterange: null,
+      duration: 10.846444,
+      timelinePosition: null,
+      cue: null,
+      uri: 'https://maitv-vod.lab.eyevinn.technology/VINN.mp4/600/600-00000.ts'
     });
     expect(newVodSegments["1313000"][2]).toEqual(expectedFirstV2LSegItem);
-    expect(newVodSegments["1313000"][5]).toEqual({
-      discontinuity: true,
-      cue: { in: true },
-    });
+    // expect(newVodSegments["1313000"][5]).toEqual({
+    //   discontinuity: true,
+    //   cue: { in: true },
+    // });
     expect(borderSegment.daterange["planned-duration"]).toEqual(vodEventDurationMs2 / 1000);
     expect("start-date" in borderSegment.daterange).toBe(true);
     expect("id" in borderSegment.daterange).toBe(true);
-    expect(borderSegment.duration).toEqual(11.3077);
+    expect(borderSegment.duration).toEqual(11.3447);
     expect(borderSegment.timelinePosition).toEqual(null);
     expect(borderSegment.cue).toEqual(null);
-    expect(borderSegment.uri).toEqual("https://maitv-vod.lab.eyevinn.technology/BECKY_Trailer_2020.mp4/600/600-00000.ts");
+    expect(borderSegment.uri).toEqual("https://maitv-vod.lab.eyevinn.technology/BECKY_Trailer_2020.mp4/1000/1000-00000.ts");
     expect(newVodSegments["1313000"][7]).toEqual(expectedSecondVODSegItem);
   });
 


### PR DESCRIPTION
This PR adds a new version on `@eyevinn/hls-vodtolive`, which allows for setting the option for creating V2L media sequences that will always contain a new segment compared with the preceding media sequence.

To use the option, one will need to add `alwaysNewSegments: true` in the engine options json.
> NOTE: channel engine will still function as before even if an older version of hls-vodtolive is being used.

PR also includes some improvements to the vod cache clearing logic and other minor bug fixes.
Furthermore, when switching back to V2L from LIVE, the target-mseq to reload/splice live-segments in front of has changed to the mseq after the current, which is more approptiate.
