### PR TITLE
Fix: Session Playhead moving too quickly when 'alwaysNewSegments' is set

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -15,6 +15,7 @@ const ChaosMonkey = require('./chaos_monkey.js');
 const AVERAGE_SEGMENT_DURATION = 3000;
 const DEFAULT_PLAYHEAD_DIFF_THRESHOLD = 1000;
 const DEFAULT_MAX_TICK_INTERVAL = 10000;
+const DIFF_CORRECTION_RATE = 0.5;
 
 const timer = ms => new Promise(res => setTimeout(res, ms));
 
@@ -212,7 +213,7 @@ class Session {
             }
           // Apply external diff compensation if available.
           if (this.diffCompensation && this.diffCompensation > 0) {
-            const DIFF_COMPENSATION = (reqTickInterval / 2).toFixed(2) * 1000;
+            const DIFF_COMPENSATION = (reqTickInterval * DIFF_CORRECTION_RATE).toFixed(2) * 1000;
             debug(`[${this._sessionId}]: Adding ${DIFF_COMPENSATION}msec to tickInterval to compensate for schedule diff (current=${this.diffCompensation}msec)`);
             tickInterval += (DIFF_COMPENSATION / 1000);
             this.diffCompensation -= DIFF_COMPENSATION;

--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -267,7 +267,7 @@ class SessionLive {
       debug(`[${this.sessionId}]: 'vodSegments' not empty = Using 'transitSegs'`);
     }
 
-    debug(`[${this.sessionId}]: Setting CurrentMediaSequenceSegments. First seg is: [${this.vodSegments[allBws[0]][0].uri}]`);
+    debug(`[${this.sessionId}]: Setting CurrentMediaSequenceSegments. First seg is: [${this.vodSegments[Object.keys(this.vodSegments)[0]][0].uri}]`);
 
     const isLeader = await this.sessionLiveStateStore.isLeader(this.instanceId);
     if (isLeader) {
@@ -501,7 +501,7 @@ class SessionLive {
           this.liveSegQueue[liveBw] = [];
         }
         // Do not push duplicates
-        const liveSegURIs = this.liveSegQueue[liveBw].filter(seg => seg.uri).map(seg => seg.uri);
+        const liveSegURIs = this.liveSegQueue[liveBw].filter((seg) => seg.uri).map((seg) => seg.uri);
         if (liveSegFromLeader.uri && liveSegURIs.includes(liveSegFromLeader.uri)) {
           debug(`[${this.sessionId}]: FOLLOWER: Found duplicate live segment. Skip push! (${liveBw})`);
         } else {
@@ -638,7 +638,7 @@ class SessionLive {
       if (manifestList.some((result) => result.status === "rejected")) {
         FETCH_ATTEMPTS--;
         debug(`[${this.sessionId}]: ALERT! Promises I: Failed, Rejection Found! Trying again in 1000ms...`);
-        await timer(1000)
+        await timer(1000);
         continue;
       }
 
@@ -678,7 +678,7 @@ class SessionLive {
         let leadersFirstSeqCounts = await this.sessionLiveState.get("firstCounts");
         let tries = 20;
 
-        while (!isLeader && (!leadersFirstSeqCounts.liveSourceMseqCount && tries > 0) || leadersFirstSeqCounts.liveSourceMseqCount === 0) {
+        while ((!isLeader && !leadersFirstSeqCounts.liveSourceMseqCount && tries > 0) || leadersFirstSeqCounts.liveSourceMseqCount === 0) {
           debug(`[${this.sessionId}]: NEW FOLLOWER: Waiting for LEADER to add 'firstCounts' in store! Will look again after 1000ms (tries left=${tries})`);
           await timer(1000);
           leadersFirstSeqCounts = await this.sessionLiveState.get("firstCounts");
@@ -719,8 +719,9 @@ class SessionLive {
         }
         if (leadersFirstSeqCounts.mediaSeqCount !== this.mediaSeqCount) {
           this.mediaSeqCount = leadersFirstSeqCounts.mediaSeqCount;
-          debug(`[${this.sessionId}]: FOLLOWER transistioned with wrong V2L segments, updating counts to [${
-            this.mediaSeqCount}][${this.discSeqCount}], and reading 'transitSegs' from store`);
+          debug(
+            `[${this.sessionId}]: FOLLOWER transistioned with wrong V2L segments, updating counts to [${this.mediaSeqCount}][${this.discSeqCount}], and reading 'transitSegs' from store`
+          );
           const transitSegs = await this.sessionLiveState.get("transitSegs");
           if (!this._isEmpty(transitSegs)) {
             this.vodSegments = transitSegs;
@@ -1070,7 +1071,7 @@ class SessionLive {
         if (startIdx < 0) {
           this.restAmount = startIdx * -1;
           startIdx = 0;
-        } 
+        }
         if (mediaManifestUri) {
           // push segments
           this._addLiveSegmentsToQueue(startIdx, m3u.items.PlaylistItem, baseUrl, liveTargetBandwidth, isLeader);
@@ -1092,7 +1093,7 @@ class SessionLive {
    * @param {string} liveTargetBandwidth
    */
   _addLiveSegmentsToQueue(startIdx, playlistItems, baseUrl, liveTargetBandwidth, isLeader) {
-    const leaderOrFollower = isLeader ? "LEADER": "NEW FOLLOWER";
+    const leaderOrFollower = isLeader ? "LEADER" : "NEW FOLLOWER";
 
     for (let i = startIdx; i < playlistItems.length; i++) {
       let seg = {};
@@ -1162,7 +1163,7 @@ class SessionLive {
           seg["daterange"] = daterangeData;
         }
         // Push new Live Segments! But do not push duplicates
-        const liveSegURIs = this.liveSegQueue[liveTargetBandwidth].filter(seg => seg.uri).map(seg => seg.uri);
+        const liveSegURIs = this.liveSegQueue[liveTargetBandwidth].filter((seg) => seg.uri).map((seg) => seg.uri);
         if (seg.uri && liveSegURIs.includes(seg.uri)) {
           debug(`[${this.sessionId}]: ${leaderOrFollower}: Found duplicate live segment. Skip push! (${liveTargetBandwidth})`);
         } else {
@@ -1372,12 +1373,12 @@ class SessionLive {
     if (this._isEmpty(this.liveSegQueue)) {
       return null;
     }
-  
-    const bw0 = Object.keys(this.liveSegQueue)[0]; 
+
+    const bw0 = Object.keys(this.liveSegQueue)[0];
     if (this.liveSegQueue[bw0].length === 0) {
       return null;
     }
-    
+
     for (let i = 0; i < this.liveSegQueue[bw0].length; i++) {
       const segment = this.liveSegQueue[bw0][i];
       if (!segment.duration) {

--- a/engine/stream_switcher.js
+++ b/engine/stream_switcher.js
@@ -482,7 +482,7 @@ class StreamSwitcher {
           if (mediaUri.match("^http")) {
             mediaURIs[bw] = mediaUri;
           } else {
-            mediaURIs[bw] = new URL(mediaUri, uri);
+            mediaURIs[bw] = new URL(mediaUri, uri).href;
           }
         }
 
@@ -575,7 +575,7 @@ class StreamSwitcher {
             if (playlistItem.properties.uri.match("^http")) {
               segmentUri = playlistItem.properties.uri;
             } else {
-              segmentUri = new URL(playlistItem.properties.uri, mediaURIs[bw]);
+              segmentUri = new URL(playlistItem.properties.uri, mediaURIs[bw]).href;
             }
             seg["duration"] = playlistItem.properties.duration;
             seg["uri"] = segmentUri;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@eyevinn/hls-repeat": "^0.1.1",
         "@eyevinn/hls-truncate": "^0.1.0",
-        "@eyevinn/hls-vodtolive": "^2.0.1",
+        "@eyevinn/hls-vodtolive": "^2.0.2",
         "@eyevinn/m3u8": "^0.4.1",
         "abort-controller": "^3.0.0",
         "debug": "^3.2.7",
@@ -80,9 +80,9 @@
       }
     },
     "node_modules/@eyevinn/hls-vodtolive": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.0.1.tgz",
-      "integrity": "sha512-rqCLt7tjF1t1M3e3U4skM0u57u80qf4ijI4iFHl7fJvF7wV6OlO62k0qRI6FXd1TMb8bs8t8ip+x+94w64b89Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.0.2.tgz",
+      "integrity": "sha512-OXVoQr0X5RWXFkbLhVDawKTVhGUbHqQ80+SMmlDBUZDrDtgA/oYhukhDo4BpVDVdKRwfg8Yl8MdHbzGaJhe81A==",
       "dependencies": {
         "@eyevinn/m3u8": "^0.4.1",
         "abort-controller": "^3.0.0",
@@ -2157,9 +2157,9 @@
       }
     },
     "@eyevinn/hls-vodtolive": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.0.1.tgz",
-      "integrity": "sha512-rqCLt7tjF1t1M3e3U4skM0u57u80qf4ijI4iFHl7fJvF7wV6OlO62k0qRI6FXd1TMb8bs8t8ip+x+94w64b89Q==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.0.2.tgz",
+      "integrity": "sha512-OXVoQr0X5RWXFkbLhVDawKTVhGUbHqQ80+SMmlDBUZDrDtgA/oYhukhDo4BpVDVdKRwfg8Yl8MdHbzGaJhe81A==",
       "requires": {
         "@eyevinn/m3u8": "^0.4.1",
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@eyevinn/hls-repeat": "^0.1.1",
     "@eyevinn/hls-truncate": "^0.1.0",
-    "@eyevinn/hls-vodtolive": "^2.0.1",
+    "@eyevinn/hls-vodtolive": "^2.0.2",
     "@eyevinn/m3u8": "^0.4.1",
     "abort-controller": "^3.0.0",
     "debug": "^3.2.7",

--- a/spec/engine/init_switching_spec.js
+++ b/spec/engine/init_switching_spec.js
@@ -413,14 +413,12 @@ describe("The initialize switching", () => {
       uri: "http://mock.mock.com/180000/seg12.ts",
     });
     expect(sessionCurrentSegs["1313000"][size - 1 - 2]).toEqual({
-      duration: 7.5,
-      timelinePosition: null,
-      uri: 'https://maitv-vod.lab.eyevinn.technology/tearsofsteel_4k.mov/600/600-00008.ts',
-      cue: null
+      discontinuity: true,
+      cue: { in: true }
     });
     expect(sessionCurrentSegs["1313000"][size - 1]).toEqual({
-      duration: 7.5,
-      uri: "https://maitv-vod.lab.eyevinn.technology/tearsofsteel_4k.mov/600/600-00010.ts",
+      duration: 11.25,
+      uri: "https://maitv-vod.lab.eyevinn.technology/tearsofsteel_4k.mov/600/600-00015.ts",
       timelinePosition: null,
       cue: null,
     });


### PR DESCRIPTION
PR fixes a schedule alignment issue, with an updated version of hls-vodotolive

When setting `alwaysNewSegments` to true in engineOptions. the number of media sequences for an HLSVod is fewer than if it was set to false. This is because we may in some sequences eject 2 or more top segments to make room for one larger segment. Thus creating 1 sequence instead of 2.

>Normally, when a new segment is too large to append, it is skipped and added to the next sequence instead.

And with fewer sequences, we get fewer playhead ticks for a VOD, e.i. 
if CE consumes the msequences at a constant pace then it will finish earlier in comparrison, thus loading the next vod too early, when using `alwaysNewSegments`.  The time difference between when a VOD is finished compared to its schedule end_time will grow larger and larger over time until a GAP vod is requested and stitched to delay the next vod and re-align it with the schedule. However, the process will just repeat itself, and the client will be given extra content to play, effectively delaying the playback of the original scheduled VOD content.

Essentially, the issue is that the way we calculate the playhead tick rate currently does not work optimally with `alwaysNewSegmets` set. The average sequence consumption rate is too fast, i.e. the tick rate is often too low.

### How things worked
Normally when a vod has been loaded too early or too late, we apply some compensation time to the **tickInterval** in the playhead function (slowing down or speeding up the playhead) to line up the broadcast to the planned schedule.

Times added to the base tickInterval are:
- Sequence delta time
- Playhead position diff compensation time
- External (schedule) diff compensation time

Currently, we add all of the comp times at once to the **tickInterval**. However, the delay that the schedule comp time adds, affects the playhead comp time for the next sequence. Eg. The schedule diff might want to slow down the playhead, but then the playhead diff would think that it is lagging behind, and will then try to speed up the playhead, e.i. try to compensate for the opposite. We have a tug-of-war situation. But as it would seem, the playhead diff wins more often.

### What has changed
This PR contains a change where, if `alwaysNewSegments` is set, will apply the playhead diff and schedule diff separately,

First, it will apply a time compensation based on the schedule diff, at a pace of half a segment length at a time.
Once it has slowed the playhead down enough, it will then update the reference time position used for calculating the playhead position difference. Adding a time position offset so that the playhead diff becomes a more appropriate value.
 
eg. 

We load a VOD with 4s segments, which is 10s early.
We get a timestamp and set **playheadRef** (reference time position) in store.
On the first 5 sequences, we add a schedule diff to the tick rate (applying an extra 2s delay).
Then we add the time position offset (10s) to the playheadRef. Making it look like there never was a schedule diff.
Lastly, with a corrected playheadRef we can continue with adding the playhead position diff compensation as per usual.
The VOD should at this point be better aligned with the scheduled VOD start and end times.

Now, in the case where the schedule diff is really high (20s+) which should only happen around the start of running CE, then there is a risk that the delays from the schedule diff compensation will cause buffer stalls for the channel. But this could be avoided by lowering pace of which we correct the schedule difference. Right now the pace is determined by:
the current base-tick inteval multiplied by 0.5 (`DIFF_CORRECTION_RATE`)
 



