### PR TITLE
Fix: cue tag still not before bumper

### DIFF
--- a/engine/stream_switcher.js
+++ b/engine/stream_switcher.js
@@ -628,6 +628,9 @@ class StreamSwitcher {
         if (lastSeg.uri && !lastSeg.discontinuity) {
           toSegments[bw].push({ discontinuity: true, cue: { in: true } });
           OUTPUT_SEGMENTS[bw] = toSegments[bw].concat(fromSegments[targetBw]);
+        } else if (lastSeg.discontinuity && !lastSeg.cue) {
+          toSegments[bw][toSegments[bw].length - 1].cue = { in: true }
+          OUTPUT_SEGMENTS[bw] = toSegments[bw].concat(fromSegments[targetBw]);
         } else {
           OUTPUT_SEGMENTS[bw] = toSegments[bw].concat(fromSegments[targetBw]);
           OUTPUT_SEGMENTS[bw].push({ discontinuity: true });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eyevinn-channel-engine",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eyevinn-channel-engine",
-      "version": "3.3.4",
+      "version": "3.3.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@eyevinn/hls-repeat": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eyevinn-channel-engine",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "description": "OTT TV Channel Engine",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
PR makes a quick fix to a minor issue.

The previous cue tag bumper issue, where it is to always add a cue in tag segment item in front of the bumper segments, missed to properly handle the case where the last segment is a solo discontinuity tag. 

Before, the function `_mergeSegments()`  (in stream_switcher.js) would add no extra segment items/tags if the V2L segments already had a tag as the last segment item. However, unless the last segment item has a cue in-tag, then it is needed to be added.

PR also updates the version from 3.3.4 to 3.3.5