### PR TITLE
fix: better check for old segments in store

### DIFF
--- a/engine/session_live.js
+++ b/engine/session_live.js
@@ -604,7 +604,7 @@ class SessionLive {
           }
         }
         if (this._containsSegment(this.liveSegsForFollowers, liveSegsInStore)) {
-          debug(`[${this.sessionId}]: FOLLOWER: _containsSegment=true,leadersMediaSeqRaw=${leadersMediaSeqRaw},this.lastRequestedMediaSeqRaw=${this.lastRequestedMediaSeqRaw}`);
+          debug(`[${this.sessionId}]: FOLLOWER: _containsSegment=true,${leadersMediaSeqRaw},${this.lastRequestedMediaSeqRaw}`);
         }
         const segDur = this._getAnyFirstSegmentDurationMs() || DEFAULT_PLAYHEAD_INTERVAL_MS;
         const waitTimeMs = parseInt(segDur / 3, 10);


### PR DESCRIPTION
TLDR; Check if store segments are old based on segment data rather than leader mseq value.

There is a small risk where the Leader node is writing to store while Follower node is reading from store in a Session Live increment, resulting in the Follower reading a new leaderMseqRaw value but an old liveSegsForFollowers values in store.

Follower node should, wait and retry reading from the store if the values in store happen to be something it has already collected in the previous increment.

