### PR TITLE
BUG: Playhead Tick Compensation Logic Blocked By Low MaxTickInterval

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -150,6 +150,7 @@ class Session {
 
     let playheadState = await this._playheadState.getValues(["state"]);
     let state = await this._playheadState.setState(PlayheadState.RUNNING);
+    let numberOfLargeTicks = 0;
     while (state !== PlayheadState.CRASHED) {
       try {
         const tsIncrementBegin = Date.now();
@@ -227,6 +228,12 @@ class Session {
           if (tickInterval <= 0.5) {
             tickInterval = 0.5;
           } else if (tickInterval > (this.maxTickInterval / 1000)) {
+            if (numberOfLargeTicks > 3) {
+              this.maxTickInterval += 2000;
+              numberOfLargeTicks = 0;
+            } else {
+              numberOfLargeTicks++;
+            }
             tickInterval = this.maxTickInterval / 1000;
           }
           debug(`[${this._sessionId}]: (${(new Date()).toISOString()}) ${timeSpentInIncrement}sec in increment. Next tick in ${tickInterval} seconds`)

--- a/engine/session.js
+++ b/engine/session.js
@@ -228,8 +228,9 @@ class Session {
           if (tickInterval <= 0.5) {
             tickInterval = 0.5;
           } else if (tickInterval > (this.maxTickInterval / 1000)) {
-            if (numberOfLargeTicks > 3) {
-              this.maxTickInterval += 2000;
+            if (numberOfLargeTicks > 2) {
+              const change = ceil(abs(tickInterval - this.maxTickInterval));
+              this.maxTickInterval += change;
               numberOfLargeTicks = 0;
             } else {
               numberOfLargeTicks++;

--- a/engine/session.js
+++ b/engine/session.js
@@ -11,7 +11,6 @@ const { PlayheadState } = require('./playhead_state.js');
 
 const { applyFilter, cloudWatchLog, m3u8Header, logerror } = require('./util.js');
 const ChaosMonkey = require('./chaos_monkey.js');
-const { config } = require('process');
 
 const AVERAGE_SEGMENT_DURATION = 3000;
 const DEFAULT_PLAYHEAD_DIFF_THRESHOLD = 1000;
@@ -230,7 +229,7 @@ class Session {
             tickInterval = 0.5;
           } else if (tickInterval > (this.maxTickInterval / 1000)) {
             const changeMaxTick = ceil(abs(tickInterval * 1000 - (this.maxTickInterval))) + 1000;
-            if (!config.maxTickInterval) {
+            if (DEFAULT_MAX_TICK_INTERVAL === this.maxTickInterval) {
               if (numberOfLargeTicks > 2) {
                 this.maxTickInterval += changeMaxTick;
                 numberOfLargeTicks = 0;

--- a/engine/session.js
+++ b/engine/session.js
@@ -43,6 +43,7 @@ class Session {
     this.cloudWatchLogging = false;
     this.playheadDiffThreshold = DEFAULT_PLAYHEAD_DIFF_THRESHOLD;
     this.maxTickInterval = DEFAULT_MAX_TICK_INTERVAL;
+    this.maxTickIntervalIsDefault = true;
     this.diffCompensationRate = DEFAULT_DIFF_COMPENSATION_RATE;
     this.diffCompensation = null;
     this.timePositionOffset = 0;
@@ -110,6 +111,7 @@ class Session {
       }
       if (config.maxTickInterval) {
         this.maxTickInterval = config.maxTickInterval;
+        this.maxTickIntervalIsDefault = false;
       }
       if (config.disabledPlayhead) {
         this.disabledPlayhead = true;
@@ -228,8 +230,8 @@ class Session {
           if (tickInterval <= 0.5) {
             tickInterval = 0.5;
           } else if (tickInterval > (this.maxTickInterval / 1000)) {
-            const changeMaxTick = ceil(abs(tickInterval * 1000 - (this.maxTickInterval))) + 1000;
-            if (DEFAULT_MAX_TICK_INTERVAL === this.maxTickInterval) {
+            const changeMaxTick = Math.ceil(Math.abs(tickInterval * 1000 - (this.maxTickInterval))) + 1000;
+            if (!this.maxTickIntervalIsDefault) {
               if (numberOfLargeTicks > 2) {
                 this.maxTickInterval += changeMaxTick;
                 numberOfLargeTicks = 0;

--- a/engine/session.js
+++ b/engine/session.js
@@ -228,13 +228,17 @@ class Session {
           if (tickInterval <= 0.5) {
             tickInterval = 0.5;
           } else if (tickInterval > (this.maxTickInterval / 1000)) {
+            const change = ceil(abs(tickInterval - this.maxTickInterval));
+            if (DEFAULT_MAX_TICK_INTERVAL === this.maxTickInterval) {
             if (numberOfLargeTicks > 2) {
-              const change = ceil(abs(tickInterval - this.maxTickInterval));
               this.maxTickInterval += change;
               numberOfLargeTicks = 0;
             } else {
               numberOfLargeTicks++;
             }
+          } else {
+            console.warn("Max tick interval is lower than segment length, It should be increased by ", change)
+          }
             tickInterval = this.maxTickInterval / 1000;
           }
           debug(`[${this._sessionId}]: (${(new Date()).toISOString()}) ${timeSpentInIncrement}sec in increment. Next tick in ${tickInterval} seconds`)

--- a/engine/session.js
+++ b/engine/session.js
@@ -231,7 +231,7 @@ class Session {
             tickInterval = 0.5;
           } else if (tickInterval > (this.maxTickInterval / 1000)) {
             const changeMaxTick = Math.ceil(Math.abs(tickInterval * 1000 - (this.maxTickInterval))) + 1000;
-            if (!this.maxTickIntervalIsDefault) {
+            if (this.maxTickIntervalIsDefault) {
               if (numberOfLargeTicks > 2) {
                 this.maxTickInterval += changeMaxTick;
                 numberOfLargeTicks = 0;


### PR DESCRIPTION
PR resolves #184 

Summary: The problem was that if maxTickInterval was set below the segment length it would cause safari to become out of sync and the player would stop requesting new manifests.