### PR TITLE
feat: Typescript types

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,11 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: 12
+          node-version: 16
           registry-url: https://registry.npmjs.org/
-      - run: npm install
-      - run: npm publish --access public
+      - run: |
+          npm install
+          npm run build
+          npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .prettierrc
+dist/

--- a/engine/server.ts
+++ b/engine/server.ts
@@ -13,7 +13,7 @@ const { SessionLiveStateStore } = require('./session_live_state.js');
 const { PlayheadStateStore } = require('./playhead_state.js');
 
 const { filterQueryParser, toHHMMSS, WaitTimeGenerator } = require('./util.js');
-const { version } = require('../../package.json');
+const { version } = require('../package.json');
 
 const timer = ms => new Promise(res => setTimeout(res, ms));
 

--- a/engine/server.ts
+++ b/engine/server.ts
@@ -32,7 +32,7 @@ export interface ChannelEngineOpts {
   sharedStoreCacheTTL?: number;
   heartbeat?: string;
   channelManager: IChannelManager;
-  streamSwitchManager?: any;
+  streamSwitchManager?: IStreamSwitchManager;
   cacheTTL?: number;
   playheadDiffThreshold?: number;
   maxTickInterval?: number;
@@ -69,9 +69,14 @@ export interface VodResponseMetadata {
   title: string;
 }
 
+export interface VodTimedMetadata {
+  'start-date': string;
+}
+
 export interface VodResponse {
   uri: string;
   currentMetadata?: VodResponseMetadata;
+  timedMetadata?: VodTimedMetadata;
 }
 
 export interface IAssetManager {
@@ -87,10 +92,39 @@ export interface ChannelProfile {
 export interface Channel {
   id: string;
   profile: ChannelProfile[];
+  audioTracks?: AudioTracks[];
+}
+
+export interface AudioTracks {
+  language: string;
+  name: string;
+  default?: boolean;
 }
 
 export interface IChannelManager {
   getChannels: () => Channel[];
+}
+
+export enum ScheduleStreamType {
+  LIVE = 1,
+  VOD = 2
+};
+
+export interface Schedule {
+  eventId: string;
+  assetId: string;
+  title: string;
+  type: ScheduleStreamType;
+  start_time: number;
+  end_time: number;
+  uri: string;
+  duration: number;
+}
+
+export interface IStreamSwitchManager {
+  generateID: () => string;
+  getPrerollUri: (channelId: string) => Promise<string>;
+  getSchedule: (channelId: string) => Promise<Schedule>;
 }
 
 export class ChannelEngine {

--- a/engine/server.ts
+++ b/engine/server.ts
@@ -31,7 +31,7 @@ export interface ChannelEngineOpts {
   memcachedUrl?: string;
   sharedStoreCacheTTL?: number;
   heartbeat?: string;
-  channelManager: any;
+  channelManager: IChannelManager;
   streamSwitchManager?: any;
   cacheTTL?: number;
   playheadDiffThreshold?: number;
@@ -76,6 +76,21 @@ export interface VodResponse {
 
 export interface IAssetManager {
   getNextVod: (vodRequest: VodRequest) => Promise<VodResponse>;
+}
+
+export interface ChannelProfile {
+  bw: number;
+  codecs: string;
+  resolution: number[];
+}
+
+export interface Channel {
+  id: string;
+  profile: ChannelProfile[];
+}
+
+export interface IChannelManager {
+  getChannels: () => Channel[];
 }
 
 export class ChannelEngine {

--- a/engine/server.ts
+++ b/engine/server.ts
@@ -118,7 +118,7 @@ export interface Schedule {
   start_time: number;
   end_time: number;
   uri: string;
-  duration: number;
+  duration?: number;
 }
 
 export interface IStreamSwitchManager {

--- a/engine/util.js
+++ b/engine/util.js
@@ -1,4 +1,4 @@
-const { version } = require("../package.json");
+const { version } = require("../../package.json");
 const fetch = require("node-fetch");
 const { AbortController } = require("abort-controller");
 

--- a/engine/util.js
+++ b/engine/util.js
@@ -1,4 +1,4 @@
-const { version } = require("../../package.json");
+const { version } = require("../package.json");
 const fetch = require("node-fetch");
 const { AbortController } = require("abort-controller");
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,0 @@
-const ChannelEngine = require('./engine/server.js');
-
-module.exports = ChannelEngine;

--- a/index.ts
+++ b/index.ts
@@ -2,8 +2,11 @@ export { ChannelEngine,
   ChannelEngineOpts, 
   IAssetManager,
   IChannelManager,
+  IStreamSwitchManager,
   VodResponse,
   VodRequest,
   Channel,
-  ChannelProfile
+  ChannelProfile,
+  AudioTracks,
+  Schedule
 } from "./engine/server";

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,6 @@
+export { ChannelEngine, 
+  ChannelEngineOpts, 
+  IAssetManager,
+  VodResponse,
+  VodRequest
+} from "./engine/server";

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,9 @@
 export { ChannelEngine, 
   ChannelEngineOpts, 
   IAssetManager,
+  IChannelManager,
   VodResponse,
-  VodRequest
+  VodRequest,
+  Channel,
+  ChannelProfile
 } from "./engine/server";

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,9 @@
         "uuid": "^8.3.2"
       },
       "devDependencies": {
-        "jasmine": "^3.1.0"
+        "@types/node": "^18.11.9",
+        "jasmine": "^3.1.0",
+        "typescript": "^4.8.4"
       }
     },
     "node_modules/@eyevinn/hls-repeat": {
@@ -144,6 +146,12 @@
       "engines": [
         "node >=0.6.0"
       ]
+    },
+    "node_modules/@types/node": {
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+      "dev": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -2008,6 +2016,19 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
     },
+    "node_modules/typescript": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -2219,6 +2240,12 @@
           "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="
         }
       }
+    },
+    "@types/node": {
+      "version": "18.11.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.9.tgz",
+      "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
+      "dev": true
     },
     "abort-controller": {
       "version": "3.0.0",
@@ -3648,6 +3675,12 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+    },
+    "typescript": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true
     },
     "unbox-primitive": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "3.3.11",
   "description": "OTT TV Channel Engine",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc --project ./ && cp ./package.json dist/",
     "debug-server": "DEBUG=engine-*,vod-to-live node dist/server.js",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "eyevinn-channel-engine",
   "version": "3.3.11",
   "description": "OTT TV Channel Engine",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
-    "debug-server": "DEBUG=engine-*,vod-to-live node server.js",
+    "build": "tsc --project ./",
+    "debug-server": "DEBUG=engine-*,vod-to-live node dist/server.js",
     "test": "$(npm bin)/jasmine",
     "postversion": "git push && git push --tags",
-    "start": "node server.js",
+    "start": "node dist/server.js",
     "start-demux": "node server-demux.js",
     "start-livemix": "node server-livemix.js"
   },
@@ -38,6 +39,8 @@
     "uuid": "^8.3.2"
   },
   "devDependencies": {
-    "jasmine": "^3.1.0"
+    "@types/node": "^18.11.9",
+    "jasmine": "^3.1.0",
+    "typescript": "^4.8.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "OTT TV Channel Engine",
   "main": "dist/index.js",
   "scripts": {
-    "build": "tsc --project ./",
+    "build": "tsc --project ./ && cp ./package.json dist/",
     "debug-server": "DEBUG=engine-*,vod-to-live node dist/server.js",
     "test": "$(npm bin)/jasmine",
     "postversion": "git push && git push --tags",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "test": "$(npm bin)/jasmine",
     "postversion": "git push && git push --tags",
     "start": "node dist/server.js",
-    "start-demux": "node server-demux.js",
-    "start-livemix": "node server-livemix.js"
+    "start-demux": "node dist/server-demux.js",
+    "start-livemix": "node dist/server-livemix.js"
   },
   "author": "Eyevinn Technology AB <work@eyevinn.se>",
   "contributors": [

--- a/server-demux.ts
+++ b/server-demux.ts
@@ -2,10 +2,16 @@
  * Reference implementation of Channel Engine library using demuxed VOD assets.
  */
 
-const ChannelEngine = require("./index.js");
+import { ChannelEngine, ChannelEngineOpts, 
+  IAssetManager, IChannelManager, 
+  VodRequest, VodResponse, Channel, ChannelProfile,
+  AudioTracks
+} from "./index";
 
-class RefAssetManager {
-  constructor(opts) {
+class RefAssetManager implements IAssetManager {
+  private assets;
+  private pos;
+  constructor(opts?) {
     this.assets = {
       1: [
         {
@@ -32,11 +38,11 @@ class RefAssetManager {
    *      playlistId
    *   }
    */
-  getNextVod(vodRequest) {
+  getNextVod(vodRequest: VodRequest): Promise<VodResponse> {
     return new Promise((resolve, reject) => {
       const channelId = vodRequest.playlistId;
       if (this.assets[channelId]) {
-        let vod = this.assets[channelId][this.pos[channelId]++];
+        let vod: VodResponse = this.assets[channelId][this.pos[channelId]++];
         if (this.pos[channelId] > this.assets[channelId].length - 1) {
           this.pos[channelId] = 0;
         }
@@ -51,12 +57,12 @@ class RefAssetManager {
   }
 }
 
-class RefChannelManager {
-  getChannels() {
+class RefChannelManager implements IChannelManager {
+  getChannels(): Channel[] {
     return [ { id: "1", profile: this._getProfile(), audioTracks: this._getAudioTracks(), }, ];
   }
 
-  _getProfile() {
+  _getProfile(): ChannelProfile[] {
     return [
       {
         bw: 7934000,
@@ -74,7 +80,7 @@ class RefChannelManager {
       { bw: 495894, codecs: "avc1.4d001f,mp4a.40.2", resolution: [480, 214] },
     ];
   }
-  _getAudioTracks() {
+  _getAudioTracks(): AudioTracks[] {
     return [
       { language: "sp", name: "Spanish" },
       { language: "ru", name: "Russian" },
@@ -86,7 +92,7 @@ class RefChannelManager {
 const refAssetManager = new RefAssetManager();
 const refChannelManager = new RefChannelManager();
 
-const engineOptions = {
+const engineOptions: ChannelEngineOpts = {
   heartbeat: "/",
   averageSegmentDuration: 2000,
   channelManager: refChannelManager,

--- a/server-livemix.ts
+++ b/server-livemix.ts
@@ -5,7 +5,7 @@
 import { ChannelEngine, ChannelEngineOpts, 
   IAssetManager, IChannelManager, IStreamSwitchManager,
   VodRequest, VodResponse, Channel, ChannelProfile,
-  AudioTracks, Schedule
+  Schedule
 } from "./index";
 const { v4: uuidv4 } = require('uuid');
 
@@ -193,7 +193,7 @@ const refAssetManager = new RefAssetManager();
 const refChannelManager = new RefChannelManager();
 const refStreamSwitchManager = new StreamSwitchManager();
 
-const engineOptions = {
+const engineOptions: ChannelEngineOpts = {
   heartbeat: "/",
   averageSegmentDuration: 2000,
   channelManager: refChannelManager,

--- a/server.ts
+++ b/server.ts
@@ -2,13 +2,15 @@
  * Reference implementation of Channel Engine library
  */
 
-const ChannelEngine = require("./index.js");
+import { ChannelEngine, ChannelEngineOpts, IAssetManager, VodRequest, VodResponse } from "./index";
 
 const STITCH_ENDPOINT =
   process.env.STITCH_ENDPOINT ||
   "http://lambda.eyevinn.technology/stitch/master.m3u8";
-class RefAssetManager {
-  constructor(opts) {
+class RefAssetManager implements IAssetManager {
+  private assets;
+  private pos;
+  constructor(opts?) {
     this.assets = {
       1: [
         {
@@ -37,7 +39,7 @@ class RefAssetManager {
    *      playlistId
    *   }
    */
-  getNextVod(vodRequest) {
+  getNextVod(vodRequest: VodRequest): Promise<VodResponse> {
     return new Promise((resolve, reject) => {
       const channelId = vodRequest.playlistId;
       if (this.assets[channelId]) {
@@ -88,7 +90,7 @@ class RefChannelManager {
 const refAssetManager = new RefAssetManager();
 const refChannelManager = new RefChannelManager();
 
-const engineOptions = {
+const engineOptions: ChannelEngineOpts = {
   heartbeat: "/",
   averageSegmentDuration: 2000,
   channelManager: refChannelManager,

--- a/server.ts
+++ b/server.ts
@@ -2,7 +2,10 @@
  * Reference implementation of Channel Engine library
  */
 
-import { ChannelEngine, ChannelEngineOpts, IAssetManager, VodRequest, VodResponse } from "./index";
+import { ChannelEngine, ChannelEngineOpts, 
+  IAssetManager, IChannelManager, 
+  VodRequest, VodResponse, Channel, ChannelProfile
+} from "./index";
 
 const STITCH_ENDPOINT =
   process.env.STITCH_ENDPOINT ||
@@ -72,13 +75,13 @@ class RefAssetManager implements IAssetManager {
   }
 }
 
-class RefChannelManager {
-  getChannels() {
+class RefChannelManager implements IChannelManager {
+  getChannels(): Channel[] {
     //return [ { id: '1', profile: this._getProfile() }, { id: 'faulty', profile: this._getProfile() } ];
     return [{ id: "1", profile: this._getProfile() }];
   }
 
-  _getProfile() {
+  _getProfile(): ChannelProfile[] {
     return [
       { bw: 6134000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [1024, 458] },
       { bw: 2323000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [640, 286] },

--- a/spec/engine/engine_spec.js
+++ b/spec/engine/engine_spec.js
@@ -1,4 +1,4 @@
-const ChannelEngine = require('../../index.js');
+const { ChannelEngine } = require('../../dist/index.js');
 
 class TestChannelManager {
   constructor() {

--- a/spec/engine/interface_spec.js
+++ b/spec/engine/interface_spec.js
@@ -1,4 +1,4 @@
-const ChannelEngine = require('../../index.js');
+const { ChannelEngine } = require('../../dist/index.js');
 
 class TestAssetManager {
   constructor(opts, assets) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "allowJs": true,
+    "target": "es5",
+    "esModuleInterop": true
+  },
+  "include": ["./server.ts", "./engine/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "outDir": "./dist",
     "allowJs": true,
     "target": "es5",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "declaration": true
   },
   "include": ["./server.ts", "./server-demux.ts", "./server-livemix.ts", "./engine/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,5 @@
     "target": "es5",
     "esModuleInterop": true
   },
-  "include": ["./server.ts", "./engine/**/*"]
+  "include": ["./server.ts", "./server-demux.ts", "./server-livemix.ts", "./engine/**/*"]
 }


### PR DESCRIPTION
This PR provides typescript types for external interfaces and classes. Porting the entire project to typescript is not part of this PR. Breaking change is related to default export and the following has changed:

```
const ChannelEngine = require("eyevinn-channel-engine");
```

is changed to:

```
const { ChannelEngine } = require("eyevinn-channel-engine");
```

Documentation site will be updated with this change.