### PR TITLE
feat: add type definition for closed captions

### DIFF
--- a/engine/server.ts
+++ b/engine/server.ts
@@ -103,6 +103,15 @@ export interface Channel {
   id: string;
   profile: ChannelProfile[];
   audioTracks?: AudioTracks[];
+  closedCaptions?: ClosedCaptions[];
+}
+
+export interface ClosedCaptions {
+  id: string;
+  lang: string;
+  name: string;
+  default?: boolean;
+  auto?: boolean;
 }
 
 export interface AudioTracks {


### PR DESCRIPTION
PR resolves #192 

Added new type definitions for closed-captions object.

Support for closed-captions has been added and is currently in the ChannelEngine.
To enable closed-captions on a channel. Specify the closed-captions config in the ChannelManager, e.g. 


```js
class RefChannelManager implements IChannelManager {
  getChannels(): Channel[] {
    return [{ id: "1", profile: this._getProfile(), closedCaptions: this._getClosedCaptions() }];
  }

  _getProfile(): ChannelProfile[] {
    return [
      { bw: 6134000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [1024, 458] },
      { bw: 2323000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [640, 286] },
      { bw: 1313000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [480, 214] },
    ];
  }

  _getClosedCaptions(): ClosedCaptions[] {
    return [
      { lang: "eng", name: "english", auto: true, default: true, id: "CC1" },
    ];
  }
}
```

This will result in the following Multivariant Playlist for the channel.
```
#EXTM3U
#EXT-X-VERSION:4
## Created with Eyevinn Channel Engine library (version=3.4.3<9bd74dbe-073a-4033-b1ec-a070890aa0a0>)
##    https://www.npmjs.com/package/eyevinn-channel-engine
#EXT-X-SESSION-DATA:DATA-ID="eyevinn.tv.session.id",VALUE="1"
#EXT-X-SESSION-DATA:DATA-ID="eyevinn.tv.eventstream",VALUE="/eventstream/1"
#EXT-X-MEDIA:TYPE=CLOSED-CAPTIONS,GROUP-ID="cc",LANGUAGE="eng",NAME="english",DEFAULT=YES,AUTOSELECT=YES,INSTREAM-ID="CC1"
#EXT-X-STREAM-INF:BANDWIDTH=6134000,RESOLUTION=1024x458,CODECS="avc1.4d001f,mp4a.40.2",CLOSED-CAPTIONS="cc"
master6134000.m3u8;session=1
#EXT-X-STREAM-INF:BANDWIDTH=2323000,RESOLUTION=640x286,CODECS="avc1.4d001f,mp4a.40.2",CLOSED-CAPTIONS="cc"
master2323000.m3u8;session=1
#EXT-X-STREAM-INF:BANDWIDTH=1313000,RESOLUTION=480x214,CODECS="avc1.4d001f,mp4a.40.2",CLOSED-CAPTIONS="cc"
master1313000.m3u8;session=1
```