### PR TITLE
fix: do not render audio stream in index manifest

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -941,16 +941,7 @@ class Session {
         m3u8 += "master" + profile.bw + ".m3u8;session=" + this._sessionId + "\n";
       });
     }
-    if (this.use_demuxed_audio === true && this._audioTracks) {
-      for (let i = 0; i < audioGroupIds.length; i++) {
-        let audioGroupId = audioGroupIds[i];
-        for (let j = 0; j < this._audioTracks.length; j++) {
-          let audioTrack = this._audioTracks[j];
-          m3u8 += `#EXT-X-STREAM-INF:BANDWIDTH=97000,CODECS="mp4a.40.2",AUDIO="${audioGroupId}"\n`;
-          m3u8 += `master-${audioGroupId}_${audioTrack.language}.m3u8;session=${this._sessionId}\n`;
-        }
-      }
-    }
+
     this.produceEvent({
       type: 'NOW_PLAYING',
       data: {

--- a/server-demux.ts
+++ b/server-demux.ts
@@ -22,8 +22,8 @@ class RefAssetManager implements IAssetManager {
       1: [
         {
           id: 1,
-          title: "Elephants Dream",
-          uri: "https://playertest.longtailvideo.com/adaptive/elephants_dream_v4/index.m3u8",
+          title: "Sintel",
+          uri: "https://cdn.bitmovin.com/content/assets/sintel/hls/playlist.m3u8",
         },
         {
           id: 2,
@@ -33,7 +33,7 @@ class RefAssetManager implements IAssetManager {
       ],
     };
     this.pos = {
-      1: 1,
+      1: 0,
     };
   }
 
@@ -90,7 +90,10 @@ class RefChannelManager implements IChannelManager {
     ];
   }
   _getAudioTracks(): AudioTracks[] {
-    return [{ language: "Swedish", name: "Swedish" }];
+    return [
+      { language: "en", name: "English" },
+      { language: "sp", name: "Spanish" }
+    ];
   }
 }
 


### PR DESCRIPTION
To render audio streams in the index manifest should not be needed as the URIs are defined in the audio rendition