### PR TITLE
fix: option to exclude session-data-tags in master manifest

### DIFF
--- a/engine/server.ts
+++ b/engine/server.ts
@@ -46,6 +46,7 @@ export interface ChannelEngineOpts {
   forceTargetDuration?: boolean;
   adCopyMgrUri?: string; // deprecated
   adXchangeUri?: string; // deprecated
+  noSessionDataTags?: boolean;
 }
 
 interface StreamerOpts {
@@ -396,6 +397,7 @@ export class ChannelEngine {
         averageSegmentDuration: channel.options && channel.options.averageSegmentDuration ? channel.options.averageSegmentDuration : this.streamerOpts.defaultAverageSegmentDuration,
         useDemuxedAudio: options.useDemuxedAudio,
         alwaysNewSegments: options.alwaysNewSegments,
+        noSessionDataTags: options.noSessionDataTags,
         playheadDiffThreshold: channel.options && channel.options.playheadDiffThreshold ? channel.options.playheadDiffThreshold : this.streamerOpts.defaultPlayheadDiffThreshold,
         maxTickInterval: channel.options && channel.options.maxTickInterval ? channel.options.maxTickInterval : this.streamerOpts.defaultMaxTickInterval,
         targetDurationPadding: channel.options && channel.options.targetDurationPadding ? channel.options.targetDurationPadding : this.streamerOpts.targetDurationPadding,

--- a/engine/session.js
+++ b/engine/session.js
@@ -97,6 +97,9 @@ class Session {
       if (config.closedCaptions) {
         this._closedCaptions = config.closedCaptions;
       }
+      if (config.noSessionDataTags) {
+        this._noSessionDataTags = config.noSessionDataTags;
+      }
       if (config.slateUri) {
         this.slateUri = config.slateUri;
         this.slateRepetitions = config.slateRepetitions || 10;
@@ -952,8 +955,10 @@ class Session {
     let m3u8 = "#EXTM3U\n";
     m3u8 += "#EXT-X-VERSION:4\n";
     m3u8 += m3u8Header(this._instanceId);
-    m3u8 += `#EXT-X-SESSION-DATA:DATA-ID="eyevinn.tv.session.id",VALUE="${this._sessionId}"\n`;
-    m3u8 += `#EXT-X-SESSION-DATA:DATA-ID="eyevinn.tv.eventstream",VALUE="/eventstream/${this._sessionId}"\n`;
+    if (!this._noSessionDataTags) {
+      m3u8 += `#EXT-X-SESSION-DATA:DATA-ID="eyevinn.tv.session.id",VALUE="${this._sessionId}"\n`;
+      m3u8 += `#EXT-X-SESSION-DATA:DATA-ID="eyevinn.tv.eventstream",VALUE="/eventstream/${this._sessionId}"\n`;
+    }
     const currentVod = await this._sessionState.getCurrentVod();
     if (!currentVod) {
       throw new Error('Session not ready');


### PR DESCRIPTION
If Channel Engine option `noSessionDataTags` is `true` the `#EXT-X-SESSION-DATA` tags are excluded from the index manifest.