### PR TITLE
fix: master manifests should be cached

### DIFF
--- a/engine/server.ts
+++ b/engine/server.ts
@@ -659,7 +659,7 @@ export class ChannelEngine {
           "Access-Control-Allow-Origin": "*",
           "Access-Control-Allow-Headers": "X-Session-Id",
           "Access-Control-Expose-Headers": "X-Session-Id",
-          "Cache-Control": "no-cache",
+          "Cache-Control": "max-age=300",
           "X-Session-Id": session.sessionId,
           "X-Instance-Id": this.instanceId + `<${version}>`,
         });


### PR DESCRIPTION
This PR adds `Cache-Control: max-age=300` to master manifest response