### PR TITLE
Fix: More CE V4 Stablization in HA-mode DRAFT

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -723,8 +723,8 @@ class Session {
       }
     } else {
       sessionState.vodMediaSeqVideo = await this._sessionState.increment("vodMediaSeqVideo");
+      let audioIncrement;
       if (this.use_demuxed_audio) {
-        let audioIncrement;
         const position = (await this._getCurrentPlayheadPosition()) * 1000;
         let currentVod = await this._sessionState.getCurrentVod();
         const sessionState = await this._sessionState.getValues(["vodMediaSeqAudio"]);
@@ -751,8 +751,8 @@ class Session {
           }
         } while (!(-thresh < posDiff && posDiff < thresh));
         audioIncrement = index;
-        sessionState.vodMediaSeqAudio = await this._sessionState.increment("vodMediaSeqAudio", audioIncrement);
       }
+      sessionState.vodMediaSeqAudio = await this._sessionState.increment("vodMediaSeqAudio", audioIncrement);
     }
 
     if (sessionState.vodMediaSeqVideo >= currentVod.getLiveMediaSequencesCount() - 1) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eyevinn-channel-engine",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eyevinn-channel-engine",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@eyevinn/hls-repeat": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,14 @@
         "node-fetch": "2.6.7"
       }
     },
+    "node_modules/@eyevinn/hls-repeat/node_modules/@eyevinn/m3u8": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.3.tgz",
+      "integrity": "sha512-FdkC95+R5X7YvJmGsmxRTOwc9mRy5BRVZOz6vVosSoK2AILWZMnox/AuTEqS3dbt1r5lnrnHbKSrNHSqtAodrg==",
+      "dependencies": {
+        "chunked-stream": "~0.0.2"
+      }
+    },
     "node_modules/@eyevinn/hls-repeat/node_modules/node-fetch": {
       "version": "2.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -66,6 +74,14 @@
       "dependencies": {
         "@eyevinn/m3u8": "0.5.3",
         "node-fetch": "2.6.2"
+      }
+    },
+    "node_modules/@eyevinn/hls-truncate/node_modules/@eyevinn/m3u8": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.3.tgz",
+      "integrity": "sha512-FdkC95+R5X7YvJmGsmxRTOwc9mRy5BRVZOz6vVosSoK2AILWZMnox/AuTEqS3dbt1r5lnrnHbKSrNHSqtAodrg==",
+      "dependencies": {
+        "chunked-stream": "~0.0.2"
       }
     },
     "node_modules/@eyevinn/hls-truncate/node_modules/node-fetch": {
@@ -128,9 +144,9 @@
       }
     },
     "node_modules/@eyevinn/m3u8": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.3.tgz",
-      "integrity": "sha512-FdkC95+R5X7YvJmGsmxRTOwc9mRy5BRVZOz6vVosSoK2AILWZMnox/AuTEqS3dbt1r5lnrnHbKSrNHSqtAodrg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.4.tgz",
+      "integrity": "sha512-i11j0sx7uCG7c9N6vsl8xccI3lKl2gf1wY+I5zs01cYIH1gXl8q0FG+oujXWBEXd67CcMqSQh9bLv0G5P6MlfA==",
       "dependencies": {
         "chunked-stream": "~0.0.2"
       }
@@ -154,9 +170,9 @@
       ]
     },
     "node_modules/@types/node": {
-      "version": "18.14.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
-      "integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.0.tgz",
+      "integrity": "sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w==",
       "dev": true
     },
     "node_modules/abort-controller": {
@@ -1027,12 +1043,12 @@
       }
     },
     "node_modules/is-array-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
-      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
       "dependencies": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "is-typed-array": "^1.1.10"
       },
       "funding": {
@@ -1661,9 +1677,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -1857,9 +1873,9 @@
       }
     },
     "node_modules/restify/node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
+      "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -2388,6 +2404,14 @@
         "node-fetch": "2.6.7"
       },
       "dependencies": {
+        "@eyevinn/m3u8": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.3.tgz",
+          "integrity": "sha512-FdkC95+R5X7YvJmGsmxRTOwc9mRy5BRVZOz6vVosSoK2AILWZMnox/AuTEqS3dbt1r5lnrnHbKSrNHSqtAodrg==",
+          "requires": {
+            "chunked-stream": "~0.0.2"
+          }
+        },
         "node-fetch": {
           "version": "2.6.7",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -2407,6 +2431,14 @@
         "node-fetch": "2.6.2"
       },
       "dependencies": {
+        "@eyevinn/m3u8": {
+          "version": "0.5.3",
+          "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.3.tgz",
+          "integrity": "sha512-FdkC95+R5X7YvJmGsmxRTOwc9mRy5BRVZOz6vVosSoK2AILWZMnox/AuTEqS3dbt1r5lnrnHbKSrNHSqtAodrg==",
+          "requires": {
+            "chunked-stream": "~0.0.2"
+          }
+        },
         "node-fetch": {
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
@@ -2449,9 +2481,9 @@
       }
     },
     "@eyevinn/m3u8": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.3.tgz",
-      "integrity": "sha512-FdkC95+R5X7YvJmGsmxRTOwc9mRy5BRVZOz6vVosSoK2AILWZMnox/AuTEqS3dbt1r5lnrnHbKSrNHSqtAodrg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.4.tgz",
+      "integrity": "sha512-i11j0sx7uCG7c9N6vsl8xccI3lKl2gf1wY+I5zs01cYIH1gXl8q0FG+oujXWBEXd67CcMqSQh9bLv0G5P6MlfA==",
       "requires": {
         "chunked-stream": "~0.0.2"
       }
@@ -2474,9 +2506,9 @@
       }
     },
     "@types/node": {
-      "version": "18.14.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
-      "integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==",
+      "version": "18.15.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.0.tgz",
+      "integrity": "sha512-z6nr0TTEOBGkzLGmbypWOGnpSpSIBorEhC4L+4HeQ2iezKCi4f77kyslRwvHeNitymGQ+oFyIWGP96l/DPSV9w==",
       "dev": true
     },
     "abort-controller": {
@@ -3155,12 +3187,12 @@
       }
     },
     "is-array-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
-      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
+      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
       "requires": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
+        "get-intrinsic": "^1.2.0",
         "is-typed-array": "^1.1.10"
       }
     },
@@ -3613,9 +3645,9 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -3751,9 +3783,9 @@
           }
         },
         "qs": {
-          "version": "6.11.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+          "version": "6.11.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.1.tgz",
+          "integrity": "sha512-0wsrzgTz/kAVIeuxSjnpGC56rzYtr6JT/2BwEvMaPhFIoYa1aGO8LbzuU1R0uUYQkLpWBTOj0l/CLAJB64J6nQ==",
           "requires": {
             "side-channel": "^1.0.4"
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eyevinn-channel-engine",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "OTT TV Channel Engine",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
PR does some fixes and improvements.

The idea of 'fast-forwarding' the audio mseq to match the playhead position of the video mseq, seems to have been implemented in the wrong place in the engine flow.
Surprisingly, the streams were still playable (enough in sync). But it may cause possible buffer stalls I believe.  

In a nutshell, first we compare current position in the video mseq vs audio mseq. If the audio mseq is behind then we check the position of the next audio mseq and compare again.
The issue is, when we do find the correct audio mseq, we do not act until the next tick. The positions should really be paired on the same tick. 

Before:
```
2023-03-08T08:05:50.095Z engine-session [1]: INCREMENT (mseq=107) vodMediaSeq=(3_5 of 13_25)  // Just incremented and current sequences are 3 for video and 5 for audio
2023-03-08T08:05:50.096Z engine-session [1]: Current delta time (3): 0
2023-03-08T08:05:50.097Z engine-session [1]: Current playhead position (3): 11.52  // Video's current position is 11.52
2023-03-08T08:05:50.100Z engine-session [1]: Current audio playhead position (5): 9.6 // Audio's current position is 9.6 (behind, when it should be caught up)
2023-03-08T08:05:50.101Z engine-session [1]: Current audio playhead position (6): 11.52 // mseq=6 is the...
... one where Audios position is caught up with video. But Current audio sequence is still 5, 
when we know the correct one is 6.

// What we did before was to increment +2 instead of +1 on the next tick. Which would help assuming that
// audio sequence 7 is more caught up to video sequence 4 in terms of playhead position.
```
After:
```
2023-03-10T09:36:32.112Z session-state-store [1]: I am incrementing key vodMediaSeqVideo with 1
2023-03-10T09:36:32.113Z engine-session [1]: Current playhead position (4): 12   // Now as soon as we increment the video mseq, we calculate which audio mseq lines up position-wise
2023-03-10T09:36:32.113Z engine-session [1]: Current audio playhead position (5): 9.6
2023-03-10T09:36:32.113Z engine-session [1]: Current audio playhead position (6): 11.52
2023-03-10T09:36:32.113Z engine-session [1]: Current audio playhead position (7): 13.44 // This sequence has a position caught up to videos position
2023-03-10T09:36:32.114Z session-state-store [1]: I am incrementing key vodMediaSeqAudio with 2 
2023-03-10T09:36:32.114Z engine-session [1]: Session can now serve mseq={333}
2023-03-10T09:36:32.114Z engine-session [1]: INCREMENT (mseq=332) vodMediaSeq=(4_7 of 9_14) // Now we see that CE is able to serve video and audio m3u8s with alined positions
```



