### PR TITLE
fix: correct audio group was not always chosen

### DIFF
--- a/engine/server.ts
+++ b/engine/server.ts
@@ -99,6 +99,7 @@ export interface ChannelProfile {
   bw: number;
   codecs: string;
   resolution: number[];
+  channels?: string;
 }
 
 export interface Channel {
@@ -119,8 +120,6 @@ export interface ClosedCaptions {
 export interface AudioTracks {
   language: string;
   name: string;
-  channels?: number;
-  codecs?: string;
   default?: boolean;
 }
 

--- a/engine/util.js
+++ b/engine/util.js
@@ -214,6 +214,16 @@ const fetchWithRetry = async (uri, opts, maxRetries, retryDelayMs, timeoutMs, de
   }
 };
 
+const codecsFromString = (codecs) => {
+  const audioCodecs = codecs.split(",").find(c => {
+    return c.match(/^mp4a/) || c.match(/^ac-3/) || c.match(/^ec-3/);
+  });
+  const videoCodecs = codecs.split(",").find(c => {
+    return c.match(/^avc/) || c.match(/^hevc/) || c.match(/^dvh/);
+  });
+  return [videoCodecs, audioCodecs];
+};
+
 module.exports = {
   filterQueryParser,
   applyFilter,
@@ -225,5 +235,6 @@ module.exports = {
   WaitTimeGenerator,
   findNearestValue,
   isValidUrl,
-  fetchWithRetry
+  fetchWithRetry,
+  codecsFromString
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@eyevinn/hls-repeat": "^0.2.0",
         "@eyevinn/hls-truncate": "^0.2.0",
-        "@eyevinn/hls-vodtolive": "^2.2.1",
+        "@eyevinn/hls-vodtolive": "^2.3.3",
         "@eyevinn/m3u8": "^0.5.3",
         "abort-controller": "^3.0.0",
         "debug": "^3.2.7",
@@ -93,11 +93,11 @@
       }
     },
     "node_modules/@eyevinn/hls-vodtolive": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.2.1.tgz",
-      "integrity": "sha512-gj0ycvNP/bnXZKd3V8snMUXv0b98KYVS2FwQ65ybdf8+QZP88Uzfv8ZuFy1M/R1vqGiYfaYpPC3y6P69DMmjgg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.3.3.tgz",
+      "integrity": "sha512-Tjx08+E/mLNhCWokAqpRQDCf4TaX12zG/W/7FkUt0ZgwPUA/XQn29yWusmsruVjED1Ugh+uxhlwL9nlQmdHSWQ==",
       "dependencies": {
-        "@eyevinn/m3u8": "^0.5.3",
+        "@eyevinn/m3u8": "^0.5.6",
         "abort-controller": "^3.0.0",
         "debug": "^4.1.1",
         "node-fetch": "2.6.7"
@@ -144,9 +144,9 @@
       }
     },
     "node_modules/@eyevinn/m3u8": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.4.tgz",
-      "integrity": "sha512-i11j0sx7uCG7c9N6vsl8xccI3lKl2gf1wY+I5zs01cYIH1gXl8q0FG+oujXWBEXd67CcMqSQh9bLv0G5P6MlfA==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.6.tgz",
+      "integrity": "sha512-aYWN9Rzofs3MCuoGrJww6vExnKg8bLHN2jAmzjK8t/akwT3bzwR3i2kqH895ZysR87mikgOzF3IaBp4OYYfwWg==",
       "dependencies": {
         "chunked-stream": "~0.0.2"
       }
@@ -2447,11 +2447,11 @@
       }
     },
     "@eyevinn/hls-vodtolive": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.2.1.tgz",
-      "integrity": "sha512-gj0ycvNP/bnXZKd3V8snMUXv0b98KYVS2FwQ65ybdf8+QZP88Uzfv8ZuFy1M/R1vqGiYfaYpPC3y6P69DMmjgg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.3.3.tgz",
+      "integrity": "sha512-Tjx08+E/mLNhCWokAqpRQDCf4TaX12zG/W/7FkUt0ZgwPUA/XQn29yWusmsruVjED1Ugh+uxhlwL9nlQmdHSWQ==",
       "requires": {
-        "@eyevinn/m3u8": "^0.5.3",
+        "@eyevinn/m3u8": "^0.5.6",
         "abort-controller": "^3.0.0",
         "debug": "^4.1.1",
         "node-fetch": "2.6.7"
@@ -2481,9 +2481,9 @@
       }
     },
     "@eyevinn/m3u8": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.4.tgz",
-      "integrity": "sha512-i11j0sx7uCG7c9N6vsl8xccI3lKl2gf1wY+I5zs01cYIH1gXl8q0FG+oujXWBEXd67CcMqSQh9bLv0G5P6MlfA==",
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.6.tgz",
+      "integrity": "sha512-aYWN9Rzofs3MCuoGrJww6vExnKg8bLHN2jAmzjK8t/akwT3bzwR3i2kqH895ZysR87mikgOzF3IaBp4OYYfwWg==",
       "requires": {
         "chunked-stream": "~0.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@eyevinn/hls-repeat": "^0.2.0",
     "@eyevinn/hls-truncate": "^0.2.0",
-    "@eyevinn/hls-vodtolive": "^2.2.1",
+    "@eyevinn/hls-vodtolive": "^2.3.3",
     "@eyevinn/m3u8": "^0.5.3",
     "abort-controller": "^3.0.0",
     "debug": "^3.2.7",

--- a/server-demux.ts
+++ b/server-demux.ts
@@ -91,8 +91,8 @@ class RefChannelManager implements IChannelManager {
   }
   _getAudioTracks(): AudioTracks[] {
     return [
-      { language: "en", name: "English" },
-      { language: "sp", name: "Spanish" }
+      { language: "en", name: "English", default: true },
+      { language: "sp", name: "Spanish", default: false }
     ];
   }
 }

--- a/server-multicodec.ts
+++ b/server-multicodec.ts
@@ -69,20 +69,20 @@ class RefChannelManager implements IChannelManager {
 
   _getProfile(): ChannelProfile[] {
     return [
-      { resolution: [640, 360], bw: 3663471, codecs: "avc1.64001F,mp4a.40.2" },
-      { resolution: [1280, 720], bw: 5841380, codecs: "avc1.64001F,mp4a.40.2" },
-      { resolution: [1920, 1080], bw: 8973571, codecs: "avc1.64001F,mp4a.40.2" },
+      { resolution: [640, 360], bw: 3663471, codecs: "avc1.64001F,mp4a.40.2", channels: "2" },
+      { resolution: [1280, 720], bw: 5841380, codecs: "avc1.64001F,mp4a.40.2", channels: "2" },
+      { resolution: [1920, 1080], bw: 8973571, codecs: "avc1.64001F,mp4a.40.2", channels: "2" },
 
-      { resolution: [640, 360], bw: 4301519, codecs: "avc1.64001F,ec-3" },
-      { resolution: [1280, 720], bw: 6479428, codecs: "avc1.64001F,ec-3" },
-      { resolution: [1920, 1080], bw: 9611619, codecs: "avc1.640032,ec-3" },
+      { resolution: [640, 360], bw: 4301519, codecs: "avc1.64001F,ec-3", channels: "16/JOC" },
+      { resolution: [1280, 720], bw: 6479428, codecs: "avc1.64001F,ec-3", channels: "16/JOC" },
+      { resolution: [1920, 1080], bw: 9611619, codecs: "avc1.640032,ec-3", channels: "16/JOC" },
     ];
   }
 
   _getAudioTracks(): AudioTracks[] {
     return [
-      { language: "ja", "name": "日本語 stereo", channels: 2, codecs: "mp4a.40.2", default: true },
-      { language: "ja", "name": "日本語 surround", channels: 16, codecs: "ec-3", default: false }
+      { language: "ja", "name": "日本語", default: true },
+      { language: "en", "name": "English", default: false }
     ];
   }
 }


### PR DESCRIPTION
This PR addresses the issue where the correct audio playlist was not always chosen when working with demuxed and VODs with multiple audio codecs. This fix assumes though that a combination of audioGroupId and Channels can be mapped to an audio playlist.