### PR TITLE
fix: upgrade redis-client that supports redis engine v6

### DIFF
--- a/engine/redis_state_store.js
+++ b/engine/redis_state_store.js
@@ -1,4 +1,4 @@
-const redis = require("redis");
+const { createClient } = require("redis");
 const debug = require("debug")("redis-state-store");
 
 const DEFAULT_VOLATILE_KEY_TTL = 5; // Timeout so it should not expire within one normal increment iteration (in seconds)
@@ -16,7 +16,7 @@ class RedisStateStore {
       debug(`Overriding default, volatileKeyTTL=${opts.volatileKeyTTL}s`);
       this.volatileKeyTTL = opts.volatileKeyTTL;  
     }
-    this.client = redis.createClient(opts.redisUrl);
+    this.client = createClient(opts.redisUrl);
   }
 
   async initAsync(id, initData) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "nock": "^13.1.1",
         "node-fetch": "^2.6.1",
         "promise.allsettled": "^1.0.4",
-        "redis": "^3.0.2",
+        "redis": "3.1.0",
         "request": ">=2.88.0",
         "restify": "9.0.0",
         "restify-errors": "^8.0.2",
@@ -1690,9 +1690,9 @@
       }
     },
     "node_modules/redis": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
-      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.0.tgz",
+      "integrity": "sha512-//lAOcEtNIKk2ekZibes5oyWKYUVWMvMB71lyD/hS9KRePNkB7AU3nXGkArX6uDKEb2N23EyJBthAv6pagD0uw==",
       "dependencies": {
         "denque": "^1.5.0",
         "redis-commands": "^1.7.0",
@@ -3655,9 +3655,9 @@
       }
     },
     "redis": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.2.tgz",
-      "integrity": "sha512-grn5KoZLr/qrRQVwoSkmzdbw6pwF+/rwODtrOr6vuBRiR/f3rjSTGupbF90Zpqm2oenix8Do6RV7pYEkGwlKkw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redis/-/redis-3.1.0.tgz",
+      "integrity": "sha512-//lAOcEtNIKk2ekZibes5oyWKYUVWMvMB71lyD/hS9KRePNkB7AU3nXGkArX6uDKEb2N23EyJBthAv6pagD0uw==",
       "requires": {
         "denque": "^1.5.0",
         "redis-commands": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "nock": "^13.1.1",
     "node-fetch": "^2.6.1",
     "promise.allsettled": "^1.0.4",
-    "redis": "^3.0.2",
+    "redis": "3.1.0",
     "request": ">=2.88.0",
     "restify": "9.0.0",
     "restify-errors": "^8.0.2",


### PR DESCRIPTION
This PR addresses #233 and contains an upgraded redis client (3.1.0) that supports Redis engine v6