### PR TITLE
fix: profile option to override audio manifest filename for a language

### DIFF
--- a/engine/server.ts
+++ b/engine/server.ts
@@ -122,6 +122,7 @@ export interface AudioTracks {
   language: string;
   name: string;
   default?: boolean;
+  enforceAudioGroupId?: string;
 }
 
 export interface IChannelManager {

--- a/engine/session.js
+++ b/engine/session.js
@@ -968,13 +968,17 @@ class Session {
             let audioTrack = this._audioTracks[j];
             const [_, channels] = currentVod.getAudioCodecsAndChannelsForGroupId(audioGroupId);
             // Make default track if set property is true.
+            let audioGroupIdFileName = audioGroupId;
+            if (audioTrack.enforceAudioGroupId) {
+              audioGroupIdFileName = audioTrack.enforceAudioGroupId;
+            }
             m3u8 += `#EXT-X-MEDIA:TYPE=AUDIO` +
               `,GROUP-ID="${audioGroupId}"` +
               `,LANGUAGE="${audioTrack.language}"` +
               `,NAME="${audioTrack.name}"` +
               `,AUTOSELECT=YES,DEFAULT=${audioTrack.default ? 'YES' : 'NO'}` +
               `,CHANNELS="${channels ? channels : 2}"` +
-              `,URI="master-${audioGroupId}_${audioTrack.language}.m3u8;session=${this._sessionId}"` +
+              `,URI="master-${audioGroupIdFileName}_${audioTrack.language}.m3u8;session=${this._sessionId}"` +
               "\n";
           }
         }


### PR DESCRIPTION
This PR adds an option to the channel profile audio track to override audio manifest filename for a specific language.
