### PR TITLE
fix: when playhead pos diff is 0 step mseq equally

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -738,7 +738,7 @@ class Session {
         do {
           const audioPosition = (await this._getAudioPlayheadPosition(sessionState.vodMediaSeqAudio + index)) * 1000;
           posDiff = position - audioPosition;
-          if (posDiff < 0) {
+          if (posDiff <= 0) {
             break;
           }
           if (posDiff > thresh) {


### PR DESCRIPTION
PR fixes a faulty if statement that allowed for unnecessary when the video playhead and audio playhead positions are perfectly aligned. 