### PR TITLE
fix: insert PDT on each segment

### DIFF
--- a/engine/server.ts
+++ b/engine/server.ts
@@ -89,6 +89,9 @@ export interface VodResponse {
   type?: string;
   currentMetadata?: VodResponseMetadata;
   timedMetadata?: VodTimedMetadata;
+  // Wall-clock start time of the VOD as unix ts. If set
+  // the program-date-time will be added to each segment
+  unixTs?: number;
 }
 
 export interface IAssetManager {

--- a/engine/session.js
+++ b/engine/session.js
@@ -1152,7 +1152,7 @@ class Session {
             if (!vodResponse.type) {
               debug(`[${this._sessionId}]: got first VOD uri=${vodResponse.uri}:${vodResponse.offset || 0}`);
               const hlsOpts = { sequenceAlwaysContainNewSegments: this.alwaysNewSegments, forcedDemuxMode: this.use_demuxed_audio };
-              newVod = new HLSVod(vodResponse.uri, [], null, vodResponse.offset * 1000, m3u8Header(this._instanceId), hlsOpts);
+              newVod = new HLSVod(vodResponse.uri, [], vodResponse.unixTs, vodResponse.offset * 1000, m3u8Header(this._instanceId), hlsOpts);
               if (vodResponse.timedMetadata) {
                 Object.keys(vodResponse.timedMetadata).map(k => {
                   newVod.addMetadata(k, vodResponse.timedMetadata[k]);
@@ -1301,7 +1301,7 @@ class Session {
             if (!vodResponse.type) {
               debug(`[${this._sessionId}]: got next VOD uri=${vodResponse.uri}:${vodResponse.offset}`);
               const hlsOpts = { sequenceAlwaysContainNewSegments: this.alwaysNewSegments, forcedDemuxMode: this.use_demuxed_audio };
-              newVod = new HLSVod(vodResponse.uri, null, null, vodResponse.offset * 1000, m3u8Header(this._instanceId), hlsOpts);
+              newVod = new HLSVod(vodResponse.uri, null, vodResponse.unixTs, vodResponse.offset * 1000, m3u8Header(this._instanceId), hlsOpts);
               if (vodResponse.timedMetadata) {
                 Object.keys(vodResponse.timedMetadata).map(k => {
                   newVod.addMetadata(k, vodResponse.timedMetadata[k]);
@@ -1532,8 +1532,8 @@ class Session {
         slateVod.load()
           .then(() => {
             const hlsOpts = { sequenceAlwaysContainNewSegments: this.alwaysNewSegments, forcedDemuxMode: this.use_demuxed_audio };
-            hlsVod = new HLSVod(this.slateUri, null, null, null, m3u8Header(this._instanceId), hlsOpts);
             const timestamp = Date.now();
+            hlsVod = new HLSVod(this.slateUri, null, timestamp, null, m3u8Header(this._instanceId), hlsOpts);
             hlsVod.addMetadata('id', `slate-${timestamp}`);
             hlsVod.addMetadata('start-date', new Date(timestamp).toISOString());
             hlsVod.addMetadata('planned-duration', ((reps || this.slateRepetitions) * this.slateDuration) / 1000);
@@ -1592,8 +1592,8 @@ class Session {
         slateVod.load()
           .then(() => {
             const hlsOpts = { sequenceAlwaysContainNewSegments: this.alwaysNewSegments, forcedDemuxMode: this.use_demuxed_audio };
-            hlsVod = new HLSVod(nexVodUri, null, null, null, m3u8Header(this._instanceId), hlsOpts);
             const timestamp = Date.now();
+            hlsVod = new HLSVod(nexVodUri, null, timestamp, null, m3u8Header(this._instanceId), hlsOpts);
             hlsVod.addMetadata('id', `slate-${timestamp}`);
             hlsVod.addMetadata('start-date', new Date(timestamp).toISOString());
             hlsVod.addMetadata('planned-duration', requestedDuration);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@eyevinn/hls-repeat": "^0.2.0",
         "@eyevinn/hls-truncate": "^0.2.0",
-        "@eyevinn/hls-vodtolive": "^2.3.5",
+        "@eyevinn/hls-vodtolive": "^2.3.7",
         "@eyevinn/m3u8": "^0.5.3",
         "abort-controller": "^3.0.0",
         "debug": "^3.2.7",
@@ -93,9 +93,9 @@
       }
     },
     "node_modules/@eyevinn/hls-vodtolive": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.3.5.tgz",
-      "integrity": "sha512-FGjj53lF+B9oHBJchRByONCYiQ1zhW0qRt55SBR5YrosT1IPqlhxo0ao3F7qu9zI13mEJmcBJ4/1Alck494S4Q==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.3.7.tgz",
+      "integrity": "sha512-vPclzZ4JRFG6WHGO3XDvcbwGDRRvuizOmic0MAQPttcqKKWQ3jZ1j+5Dm/RUllapKoOhgrdSelUo550yuwfV+g==",
       "dependencies": {
         "@eyevinn/m3u8": "^0.5.6",
         "abort-controller": "^3.0.0",
@@ -2476,9 +2476,9 @@
       }
     },
     "@eyevinn/hls-vodtolive": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.3.5.tgz",
-      "integrity": "sha512-FGjj53lF+B9oHBJchRByONCYiQ1zhW0qRt55SBR5YrosT1IPqlhxo0ao3F7qu9zI13mEJmcBJ4/1Alck494S4Q==",
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.3.7.tgz",
+      "integrity": "sha512-vPclzZ4JRFG6WHGO3XDvcbwGDRRvuizOmic0MAQPttcqKKWQ3jZ1j+5Dm/RUllapKoOhgrdSelUo550yuwfV+g==",
       "requires": {
         "@eyevinn/m3u8": "^0.5.6",
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@eyevinn/hls-repeat": "^0.2.0",
     "@eyevinn/hls-truncate": "^0.2.0",
-    "@eyevinn/hls-vodtolive": "^2.3.5",
+    "@eyevinn/hls-vodtolive": "^2.3.7",
     "@eyevinn/m3u8": "^0.5.3",
     "abort-controller": "^3.0.0",
     "debug": "^3.2.7",

--- a/spec/engine/init_switching_spec.js
+++ b/spec/engine/init_switching_spec.js
@@ -468,6 +468,7 @@ describe("The initialize switching", () => {
     if (m) {
       mseqNo = Number(m[1]);
     }
+    
     expect(mseqNo).toBe(10);
     const size = sessionCurrentSegs["1313000"].length;
     expect(sessionCurrentSegs["1313000"][0]).toEqual({
@@ -484,7 +485,7 @@ describe("The initialize switching", () => {
     const borderSegment = sessionCurrentSegs["1313000"][size - 1 - 3];
     expect(borderSegment.duration).toBe(10.880);
     expect(borderSegment.cue).toBe(null);
-    expect(borderSegment.timelinePosition).toBe(null);
+    expect(borderSegment.timelinePosition).not.toBe(null);
     expect(borderSegment.uri).toBe("https://maitv-vod.lab.eyevinn.technology/MORBIUS_Trailer_2020.mp4/1000/1000-00000.ts");
     expect(borderSegment.daterange["id"]).not.toBe(null);
     expect(borderSegment.daterange["start-date"]).not.toBe(null);
@@ -768,13 +769,11 @@ describe("The initialize switching", () => {
     }
 
     expect(newVodSegments["1313000"][0]).toEqual(expectedLastVODSegItem);
-    expect(newVodSegments["1313000"][1]).toEqual({
-      duration: 10.846444,
-      timelinePosition: null,
-      cue: null,
-      uri: 'https://maitv-vod.lab.eyevinn.technology/VINN.mp4/600/600-00000.ts',
-      byteRange: undefined,
-    });
+    expect(newVodSegments["1313000"][1].duration).toEqual(10.846444);
+    expect(newVodSegments["1313000"][1].cue).toBeNull();
+    expect(newVodSegments["1313000"][1].uri).toEqual('https://maitv-vod.lab.eyevinn.technology/VINN.mp4/600/600-00000.ts');
+
+    newVodSegments["1313000"][2].timelinePosition = null; // disregard timeline position
     expect(newVodSegments["1313000"][2]).toEqual(expectedFirstV2LSegItem);
     // expect(newVodSegments["1313000"][5]).toEqual({
     //   discontinuity: true,
@@ -784,9 +783,11 @@ describe("The initialize switching", () => {
     expect("start-date" in borderSegment.daterange).toBe(true);
     expect("id" in borderSegment.daterange).toBe(true);
     expect(borderSegment.duration).toEqual(11.3447);
-    expect(borderSegment.timelinePosition).toEqual(null);
+    expect(borderSegment.timelinePosition).not.toEqual(null);
     expect(borderSegment.cue).toEqual(null);
     expect(borderSegment.uri).toEqual("https://maitv-vod.lab.eyevinn.technology/BECKY_Trailer_2020.mp4/1000/1000-00000.ts");
+
+    newVodSegments["1313000"][7].timelinePosition = null; // disregard timeline position
     expect(newVodSegments["1313000"][7]).toEqual(expectedSecondVODSegItem);
   });
 


### PR DESCRIPTION
This PR addresses #243 and adds PDT on each segment given that the vod-response from the asset manager contains wall-clock time of the VOD start time as a unix timestamp.

```
export interface VodResponse {
  ...
  // Wall-clock start time of the VOD as unix ts. If set
  // the program-date-time will be added to each segment
  unixTs?: number;
}
```