### PR TITLE
fix: handle VOD without byterange offsets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@eyevinn/hls-repeat": "^0.2.0",
         "@eyevinn/hls-truncate": "^0.2.0",
-        "@eyevinn/hls-vodtolive": "^2.3.8",
+        "@eyevinn/hls-vodtolive": "^2.3.9",
         "@eyevinn/m3u8": "^0.5.3",
         "abort-controller": "^3.0.0",
         "debug": "^3.2.7",
@@ -96,9 +96,9 @@
       }
     },
     "node_modules/@eyevinn/hls-vodtolive": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.3.8.tgz",
-      "integrity": "sha512-aN7vRreLkgImv8YprCVununPiSF6NzJzHsRDYo5JmeBjUXQ5VCTWFooDft+tZfj/tyvJwYredJPeEPS3X6FjQg==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.3.9.tgz",
+      "integrity": "sha512-4WNAGrOHmD6yTuPJlxzzK4fXUTD5Ssp2W0ps+EEwvWK9z+lC8OBiEeq7civURwPsdvU0ISApKsmkUwmQXNBbDA==",
       "dependencies": {
         "@eyevinn/m3u8": "^0.5.6",
         "abort-controller": "^3.0.0",
@@ -2479,9 +2479,9 @@
       }
     },
     "@eyevinn/hls-vodtolive": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.3.8.tgz",
-      "integrity": "sha512-aN7vRreLkgImv8YprCVununPiSF6NzJzHsRDYo5JmeBjUXQ5VCTWFooDft+tZfj/tyvJwYredJPeEPS3X6FjQg==",
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-2.3.9.tgz",
+      "integrity": "sha512-4WNAGrOHmD6yTuPJlxzzK4fXUTD5Ssp2W0ps+EEwvWK9z+lC8OBiEeq7civURwPsdvU0ISApKsmkUwmQXNBbDA==",
       "requires": {
         "@eyevinn/m3u8": "^0.5.6",
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@eyevinn/hls-repeat": "^0.2.0",
     "@eyevinn/hls-truncate": "^0.2.0",
-    "@eyevinn/hls-vodtolive": "^2.3.8",
+    "@eyevinn/hls-vodtolive": "^2.3.9",
     "@eyevinn/m3u8": "^0.5.3",
     "abort-controller": "^3.0.0",
     "debug": "^3.2.7",


### PR DESCRIPTION
Handle VOD with BYTERANGE that are not providing offset on each segment. Normalizes the source VOD by calculating and adding the offset on each segment in those cases where it is missing.