### PR TITLE
fix: changed endpoint for vtt dummy and slice endpoint

### DIFF
--- a/engine/server.ts
+++ b/engine/server.ts
@@ -23,8 +23,8 @@ const sessionsLive = {}; // Should be a persistent store...
 const sessionSwitchers = {}; // Should be a persistent store...
 const switcherStatus = {}; // Should be a persistent store...
 const eventStreams = {};
-const DefaultDummySubtitleEndpointPath = "dummyUrl"
-const DefaultSubtitleSpliceEndpointPath = "sliceUrl"
+const DefaultDummySubtitleEndpointPath = "/vtt/dummyUrl"
+const DefaultSubtitleSpliceEndpointPath = "/vtt/sliceUrl"
 
 export interface ChannelEngineOpts {
   defaultSlateUri?: string;
@@ -335,8 +335,8 @@ export class ChannelEngine {
     this.server.get('/health', this._handleAggregatedSessionHealth.bind(this));
     this.server.get('/health/:sessionId', this._handleSessionHealth.bind(this));
     this.server.get('/reset', this._handleSessionReset.bind(this));
-    this.server.get('/channels/:channelId/' + this.dummySubtitleEndpoint, this._handleDummySubtitleEndpoint.bind(this));
-    this.server.get('/channels/:channelId/' + this.subtitleSliceEndpoint, this._handleSubtitleSliceEndpoint.bind(this));
+    this.server.get(this.dummySubtitleEndpoint, this._handleDummySubtitleEndpoint.bind(this));
+    this.server.get(this.subtitleSliceEndpoint, this._handleSubtitleSliceEndpoint.bind(this));
 
     this.server.on('NotFound', (req, res, err, next) => {
       res.header("X-Instance-Id", this.instanceId + `<${version}>`);


### PR DESCRIPTION
no need to use a channel specific endpoint url for these functions