### PR TITLE
feat: truncate VOD if requested

### DIFF
--- a/engine/server.ts
+++ b/engine/server.ts
@@ -99,7 +99,7 @@ export interface VodResponse {
   uri: string;
   offset?: number;
   diffMs?: number;
-  desiredDuraiton?: number;
+  desiredDuration?: number;
   type?: string;
   currentMetadata?: VodResponseMetadata;
   timedMetadata?: VodTimedMetadata;


### PR DESCRIPTION
If a `desiredDuration` is included in the VOD response from the adapter the engine will truncate the VOD to be as close as possible as requested.