### PR TITLE
fix: Ensure CurrentVod Is Only Ever Set By Leader

### DIFF
--- a/engine/session_state.js
+++ b/engine/session_state.js
@@ -75,12 +75,12 @@ class SharedSessionState {
     }
 
     if (this.store.isShared()) {
-      let newHlsVodJson = await this.set("currentVod", hlsVod.toJSON());
+      await this.store.clearLeaderCache();
       const isLeader = await this.store.isLeader(this.instanceId);
-      if (!isLeader) {
+      if (isLeader) {
+        await this.set("currentVod", hlsVod.toJSON());
+      } else {
         debug(`[${this.sessionId}]: not a leader, will not overwrite currentVod in shared store`);
-        hlsVod = new HLSVod();
-        hlsVod.fromJSON(newHlsVodJson);
       }
     } else {
       await this.set("currentVod", hlsVod);


### PR DESCRIPTION
When resetting the store, the title for a leader is up for grabs, and a new leader can be crowned.
However, the new follower (in this case ex-leader) node could still have its own instanceId in its leader cache for a couple more seconds.
If the CE is ever in this state right before loading a vod, then the follower node could set the currentVod, and store it in the local cache. Even if it a few seconds later corrects itself and realizes that it is NOT the leader, it still has the 'wrong' currentVod in the local cache and will not clear it, while the 'real' currentVod is available in the store (set there by the leader).

The result will be that the nodes are desynced, i.e. The nodes are serving manifests from different vods.

This PR attempts to solve this, by ensuring that only real leaders are allowed to set the current vod, by always clearing the leader cache before attempting to set a current vod. This way no ex-leader will ever have the authority to set things.