### PR TITLE
Handle Case Where Follower-Node Does Not Get The CurrentVod

### DIFF
--- a/engine/session_state.js
+++ b/engine/session_state.js
@@ -73,14 +73,16 @@ class SharedSessionState {
     if (!this.sessionId) {
       throw new Error("shared session state store has not been initialized");
     }
-
     if (this.store.isShared()) {
       await this.store.clearLeaderCache();
       const isLeader = await this.store.isLeader(this.instanceId);
       if (isLeader) {
         await this.set("currentVod", hlsVod.toJSON());
       } else {
-        debug(`[${this.sessionId}]: not a leader, will not overwrite currentVod in shared store`);
+        debug(`[${this.sessionId}]: Not a leader. Will not overwrite. Getting currentVod in shared store`);
+        const currentVod = await this.get("currentVod");
+        hlsVod = new HLSVod();
+        hlsVod.fromJSON(currentVod);
       }
     } else {
       await this.set("currentVod", hlsVod);


### PR DESCRIPTION
Even though a follower node is never supposed to set vods in storage, there are a few cases where it can happen. Where a follower node might find itself in a state where it thinks it is allowed to set the currentVod, it needs to be fed the actual currentVod when attempting. 

Right now when it tries `setCurrentVod(..)` does not do this.