### PR TITLE
fix: decouple restify path and endpoint config dependency

### DIFF
--- a/engine/server.ts
+++ b/engine/server.ts
@@ -349,8 +349,8 @@ export class ChannelEngine {
     this.server.get('/health', this._handleAggregatedSessionHealth.bind(this));
     this.server.get('/health/:sessionId', this._handleSessionHealth.bind(this));
     this.server.get('/reset', this._handleSessionReset.bind(this));
-    this.server.get(this.dummySubtitleEndpoint, this._handleDummySubtitleEndpoint.bind(this));
-    this.server.get(this.subtitleSliceEndpoint, this._handleSubtitleSliceEndpoint.bind(this));
+    this.server.get(DefaultDummySubtitleEndpointPath, this._handleDummySubtitleEndpoint.bind(this));
+    this.server.get(DefaultSubtitleSpliceEndpointPath, this._handleSubtitleSliceEndpoint.bind(this));
 
     this.server.on('NotFound', (req, res, err, next) => {
       res.header("X-Instance-Id", this.instanceId + `<${version}>`);


### PR DESCRIPTION
Setting the engine option `dummySubtittleEndpoint` decides what URI each dummy subtitle segment should have. The thought is that this URL should point to an empty webvtt file located somewhere on the public internet. 
However, when setting a string that is an absolute URL, the engine bugs and breaks.

This PR will resolve that issue.
