### PR TITLE
fix: audioIncrement stepping when it should not due to float point error

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -840,7 +840,7 @@ class Session {
         do {
           const audioPosition = (await this._getAudioPlayheadPosition(sessionState.vodMediaSeqAudio + index)) * 1000;
           positionA = audioPosition / 1000;
-          posDiff = position - audioPosition;
+          posDiff = (positionV-positionA).toFixed(3);
           if (posDiff <= 0.001) {
             break;
           }
@@ -856,7 +856,7 @@ class Session {
           }
         } while (!(-thresh < posDiff && posDiff < thresh));
         audioIncrement = index;
-        debug(`[${this._sessionId}]: Current VOD Playhead Positions are to be: [${positionV.toFixed(3)}][${positionA.toFixed(3)}] (${(positionA-positionV).toFixed(3)})`);
+        debug(`[${this._sessionId}]: Current VOD Playhead Positions are to be: [${positionV.toFixed(3)}][${positionA.toFixed(3)}] (${posDiff})`);
       }
       debug(`[${this._sessionId}]: Will increment audio with ${audioIncrement}`);
       sessionState.vodMediaSeqAudio = await this._sessionState.increment("vodMediaSeqAudio", audioIncrement);


### PR DESCRIPTION
For a demuxed stream, the CE tries to keep the video and audio streams aligned as best as possible.
It does this by comparing each track's playhead position value for a particular mseq.

If the difference is significant enough then it will increment the audio track faster than video.
If this happens, the audio track should also be able to skip an increment to allow for the video stream to catch up.   

However, when comparing current playhead positions, the difference could be really small. i.e. 0.0000002 
Due to what could be Javascript floating point error. So in a case where the diff should have equated to Zero, but didn't, the wrong behavior gets triggered. Resulting in the audio track not allowing the video track to catch up when it should have. 
i.e. The Audio track is constantly 1 media sequence ahead of video when it shouldn't be.

**PR resolves this by increasing the threshold condition for deciding if the position difference is small enough.**