### PR TITLE
fix: audio increment calculation stepping when it should not V3

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -836,19 +836,23 @@ class Session {
         let index = 0;
         const audioSeqLastIdx = currentVod.getLiveMediaSequencesCount("audio") - 1;
         const thresh = 0.5;
+        const maxAcceptableDiff = 0.001;
         debug(`[${this._sessionId}]: About to determine audio increment`);
         do {
           const audioPosition = (await this._getAudioPlayheadPosition(sessionState.vodMediaSeqAudio + index)) * 1000;
           positionA = audioPosition / 1000;
           posDiff = (positionV-positionA).toFixed(3);
-          if (posDiff <= 0.001) {
+          debug(`[${this._sessionId}]: positionV=${positionV};positionA=${positionA};posDiff=${posDiff};(posDiff <= 0.001)=${posDiff <= 0.001}`);
+          if (posDiff <= maxAcceptableDiff) {
+            debug(`[${this._sessionId}]: posDiff value (${posDiff}) is acceptable`);
             break;
           }
           if (posDiff > thresh) {
             index++;
             incrementValue++;
-          } else {
+          } else if (posDiff > maxAcceptableDiff) {
             index = incrementValue;
+            debug(`[${this._sessionId}]: Audio Stepping index set to = ${index}`);
             break;
           }
           if (sessionState.vodMediaSeqAudio + index > audioSeqLastIdx) {


### PR DESCRIPTION
PR is a revised fix for the previous issue of 
```
For a demuxed stream, the CE tries to keep the video and audio streams aligned as best as possible.
It does this by comparing each track's playhead position value for a particular mseq.

If the difference is significant enough then it will increment the audio track faster than video.
If this happens, the audio track should also be able to skip an increment to allow for the video stream to catch up.

However, when comparing current playhead positions, the difference could be really small. i.e. 0.0000002
Due to what could be Javascript floating point error. So in a case where the diff should have equated to Zero, but didn't, the wrong behavior gets triggered. Resulting in the audio track not allowing the video track to catch up when it should have.
i.e. The Audio track is constantly 1 media sequence ahead of video when it shouldn't be.

PR resolves this by increasing the threshold condition for deciding if the position difference is small enough.
```