### PR TITLE
Feat: Add Reset by Channel feature

### DIFF
--- a/engine/memcached_state_store.js
+++ b/engine/memcached_state_store.js
@@ -36,6 +36,10 @@ class MemcachedStateStore {
     await this.initAsync(id, initData);
   }
 
+  async resetAllAsync() {
+    console.error("Shared Storage Reset Failed.\nMemcache-client: Flush All Command Not Implemented Yet");
+  }
+
   async getAsync(id, key) {
     const storeKey = "" + this.keyPrefix + id + key;
     const data = await this.client.get(storeKey);

--- a/engine/memory_state_store.js
+++ b/engine/memory_state_store.js
@@ -31,6 +31,9 @@ class MemoryStateStore {
     if (id === "" || id === null) {
       value = this.globalSharedStates[key];
     } else {
+      if (!this.sharedStates[id]) {
+        return null;
+      }
       value = this.sharedStates[id][key];
     }
     return value;
@@ -40,6 +43,9 @@ class MemoryStateStore {
     if (id === "" || id === null) {
       this.globalSharedStates[key] = value;
     } else {
+      if (!this.sharedStates[id]) {
+        this.sharedStates[id] = {};
+      }
       this.sharedStates[id][key] = value;
       return this.sharedStates[id][key];
     }

--- a/engine/memory_state_store.js
+++ b/engine/memory_state_store.js
@@ -9,11 +9,21 @@ class MemoryStateStore {
   async initAsync(id, initData) {
     if (!this.sharedStates[id]) {
       this.sharedStates[id] = {};
-      Object.keys(initData).forEach(key => {
+      Object.keys(initData).forEach((key) => {
         this.sharedStates[id][key] = initData[key];
       });
     }
     return this.sharedStates[id];
+  }
+
+  async resetAsync(id, initData) {
+    this.sharedStates[id] = null;
+    await this.initAsync(id, initData);
+  }
+
+  async resetAllAsync() {
+      this.sharedStates = {};
+      this.globalSharedStates = {};
   }
 
   async getAsync(id, key) {
@@ -41,7 +51,7 @@ class MemoryStateStore {
 
   async removeAsync(id, key) {
     delete this.sharedStates[id][key];
-  }  
+  }
 }
 
 module.exports = MemoryStateStore;

--- a/engine/redis_state_store.js
+++ b/engine/redis_state_store.js
@@ -14,7 +14,7 @@ class RedisStateStore {
     this.volatileKeyTTL = DEFAULT_VOLATILE_KEY_TTL;
     if (opts.volatileKeyTTL) {
       debug(`Overriding default, volatileKeyTTL=${opts.volatileKeyTTL}s`);
-      this.volatileKeyTTL = opts.volatileKeyTTL;  
+      this.volatileKeyTTL = opts.volatileKeyTTL;
     }
     this.client = createClient(opts.redisUrl);
   }
@@ -23,14 +23,14 @@ class RedisStateStore {
     const isInitiated = await this.getAsync(id, "_initiated");
     let data = {};
     if (!isInitiated) {
-      for(const key of Object.keys(initData)) {
+      for (const key of Object.keys(initData)) {
         debug(`${this.keyPrefix}:${id}: Initiating key ${key} with init data`);
         data[key] = await this.setAsync(id, key, initData[key]);
       }
       await this.setAsync(id, "_initiated", true);
     } else {
       debug(`${this.keyPrefix}:${id}: Already initiated, not initiating with init data`);
-      for(const key of Object.keys(initData)) {
+      for (const key of Object.keys(initData)) {
         debug(`${this.keyPrefix}:${id}: Initiating key ${key} with data from store`);
         data[key] = await this.getAsync(id, key);
       }
@@ -39,8 +39,13 @@ class RedisStateStore {
   }
 
   async resetAsync(id, initData) {
+      await this.setAsync(id, "_initiated", false);
+      await this.initAsync(id, initData);
+  }
+
+  async resetAllAsync() {
     const resetAsync = new Promise((resolve, reject) => {
-      this.client.flushall((err, reply) => {        
+      this.client.flushall((err, reply) => {
         if (!err) {
           console.log("Flushed Redis db: ", reply);
           resolve();
@@ -64,7 +69,7 @@ class RedisStateStore {
         } else {
           reject(err);
         }
-        });
+      });
     });
     const data = await getAsync;
     return data;
@@ -76,7 +81,7 @@ class RedisStateStore {
     const setAsync = new Promise((resolve, reject) => {
       this.client.set(storeKey, JSON.stringify(value), (err, res) => {
         const ioTimeMs = Date.now() - startMs;
-        debug(`REDIS set ${storeKey}: ${res} (${ioTimeMs}ms) ${ioTimeMs > 1000 ? 'REDISSLOW!' : ''}`);
+        debug(`REDIS set ${storeKey}: ${res} (${ioTimeMs}ms) ${ioTimeMs > 1000 ? "REDISSLOW!" : ""}`);
         if (!err) {
           resolve(value);
         } else {
@@ -110,7 +115,7 @@ class RedisStateStore {
     const delAsync = new Promise((resolve, reject) => {
       this.client.del(storeKey, (err, res) => {
         const ioTimeMs = Date.now() - startMs;
-        debug(`REDIS remove ${storeKey}: (${ioTimeMs}ms) ${ioTimeMs > 1000 ? 'REDISSLOW!' : ''}`);
+        debug(`REDIS remove ${storeKey}: (${ioTimeMs}ms) ${ioTimeMs > 1000 ? "REDISSLOW!" : ""}`);
         if (!err) {
           resolve();
         } else {

--- a/engine/session.js
+++ b/engine/session.js
@@ -341,9 +341,13 @@ class Session {
     }
   }
 
-  async resetAsync() {
-    await this._sessionStateStore.reset(this._sessionId);
-    await this._playheadStateStore.reset(this._sessionId);
+  async resetAsync(id) {
+    if (id) {
+      await this._sessionStateStore.reset(id);
+      await this._playheadStateStore.reset(id);
+    }
+    await this._sessionStateStore.resetAll();
+    await this._playheadStateStore.resetAll();
   }
 
   async getSessionState() {

--- a/engine/shared_state_store.js
+++ b/engine/shared_state_store.js
@@ -38,6 +38,10 @@ class SharedStateStore {
     await this.store.resetAsync(id, this.initData);
   }
 
+  async resetAll() {
+    await this.store.resetAllAsync();
+  }
+
   async get(id, key) {
     //debug(`${this.type}:${id}:${key} Reading from shared store`);
     let data = await this.store.getAsync(id, key);


### PR DESCRIPTION
This PR resolves #285 

Also added a new option `sessionResetKey`.
When set, the `/reset` and `/reset/:id` endpoints will start to require a matching API key in the request query in order to perform a reset.
eg, 
```
https://vc.engine.host.com/reset?key=<sessionResetKey>
```
