### PR TITLE
Fix: Disable Eventstream by Default

### DIFF
--- a/engine/server.ts
+++ b/engine/server.ts
@@ -61,6 +61,7 @@ export interface ChannelEngineOpts {
   autoCreateSession?: boolean;
   sessionResetKey?: string;
   keepAliveTimeout?: number;
+  sessionEventStream?: boolean;
 }
 
 interface StreamerOpts {
@@ -207,6 +208,7 @@ export class ChannelEngine {
   private adXchangeUri?: string;
   private autoCreateSession: boolean = false;
   private sessionResetKey: string = "";
+  private sessionEventStream: boolean = false;
   
   constructor(assetMgr: IAssetManager, options?: ChannelEngineOpts) {
     this.options = options;
@@ -497,6 +499,7 @@ export class ChannelEngine {
         slateRepetitions: channel.slate && channel.slate.repetitions ? channel.slate.repetitions : this.slateRepetitions,
         slateDuration: channel.slate && channel.slate.duration ? channel.slate.duration : this.slateDuration,
         cloudWatchMetrics: this.logCloudWatchMetrics,
+        sessionEventStream: options.sessionEventStream
       }, this.sessionStore);
 
       sessionsLive[channel.id] = new SessionLive({

--- a/engine/session.js
+++ b/engine/session.js
@@ -1207,8 +1207,8 @@ class Session {
     this.produceEvent({
       type: 'NOW_PLAYING',
       data: {
-        id: this.currentMetadata.id || 'cc',
-        title: this.currentMetadata.title || 'cc',
+        id: this.currentMetadata.id,
+        title: this.currentMetadata.title,
       }
     });
     this._sessionState.set("tsLastRequestMaster", Date.now());
@@ -1405,8 +1405,8 @@ class Session {
             this.produceEvent({
               type: 'NOW_PLAYING',
               data: {
-                id: this.currentMetadata.id || 'xx',
-                title: this.currentMetadata.title || 'xx',
+                id: this.currentMetadata.id,
+                title: this.currentMetadata.title,
               }
             });
             sessionState.currentVod = await this._sessionState.setCurrentVod(currentVod, { ttl: currentVod.getDuration() * 1000 });
@@ -1546,9 +1546,9 @@ class Session {
               this.produceEvent({
                 type: 'NEXT_VOD_SELECTED',
                 data: {
-                  id: this.currentMetadata.id|| 'xx',
-                  uri: vodResponse.uri|| 'xx',
-                  title: this.currentMetadata.title || '',
+                  id: this.currentMetadata.id,
+                  uri: vodResponse.uri,
+                  title: this.currentMetadata.title,
                 }
               });
               if (vodResponse.desiredDuration) {
@@ -1608,8 +1608,8 @@ class Session {
             this.produceEvent({
               type: 'NOW_PLAYING',
               data: {
-                id: this.currentMetadata.id || 'cc',
-                title: this.currentMetadata.title || 'dc',
+                id: this.currentMetadata.id,
+                title: this.currentMetadata.title,
               }
             });
             return;

--- a/engine/session.js
+++ b/engine/session.js
@@ -1548,7 +1548,7 @@ class Session {
                 data: {
                   id: this.currentMetadata.id,
                   uri: vodResponse.uri,
-                  title: this.currentMetadata.title,
+                  title: this.currentMetadata.title || '',
                 }
               });
               if (vodResponse.desiredDuration) {


### PR DESCRIPTION
PR resolves #297 by introducing a new engine option `sessionEventStream: boolean` 

Enabling this option, indicates that you plan on polling the CE for a stream of session specific events.