### PR TITLE
feat: option to protect session health endpoint with a key

### DIFF
--- a/engine/preflight.js
+++ b/engine/preflight.js
@@ -1,0 +1,44 @@
+const constants = {
+  ALLOW_HEADERS: [
+    'accept',
+    'accept-version',
+    'content-type',
+    'request-id',
+    'origin',
+    'x-api-version',
+    'x-request-id',
+    'x-requested-with'
+  ],
+  EXPOSE_HEADERS: [
+    'api-version',
+    'content-length',
+    'content-md5',
+    'content-type',
+    'date',
+    'request-id',
+    'response-time'
+  ],
+  AC_REQ_METHOD: 'access-control-request-method',
+  AC_REQ_HEADERS: 'access-control-request-headers',
+  AC_ALLOW_CREDS: 'access-control-allow-credentials',
+  AC_ALLOW_ORIGIN: 'access-control-allow-origin',
+  AC_ALLOW_HEADERS: 'access-control-allow-headers',
+  AC_ALLOW_METHODS: 'access-control-allow-methods',
+  AC_EXPOSE_HEADERS: 'access-control-expose-headers',
+  AC_MAX_AGE: 'access-control-max-age',
+  STR_VARY: 'vary',
+  STR_ORIGIN: 'origin',
+  HTTP_NO_CONTENT: 204
+}
+
+exports.handler = function (req, res, next) {
+  if (req.method !== 'OPTIONS') return next();
+  res.once('header', function () {
+    res.header(constants.AC_ALLOW_ORIGIN, '*');
+    res.header(constants.AC_ALLOW_CREDS, true);
+    res.header(constants.AC_ALLOW_METHODS, ['GET', 'OPTIONS']);
+    res.header(constants.AC_ALLOW_HEADERS, ['x-health-key']);
+  });
+
+  res.send(constants.HTTP_NO_CONTENT);
+}

--- a/examples/default.ts
+++ b/examples/default.ts
@@ -106,7 +106,8 @@ const engineOptions: ChannelEngineOpts = {
     "https://maitv-vod.lab.eyevinn.technology/slate-consuo.mp4/master.m3u8",
   slateRepetitions: 10,
   redisUrl: process.env.REDIS_URL,
-  keepAliveTimeout: process.env.KEEP_ALIVE_TIMEOUT ? parseInt(process.env.KEEP_ALIVE_TIMEOUT) * 1000: undefined
+  keepAliveTimeout: process.env.KEEP_ALIVE_TIMEOUT ? parseInt(process.env.KEEP_ALIVE_TIMEOUT) * 1000: undefined,
+  sessionHealthKey: 'eyevinn'
 };
 
 const engine = new ChannelEngine(refAssetManager, engineOptions);


### PR DESCRIPTION
If engine option `sessionHealthKey` is set it is mandated to provide the header 'x-health-key' in the GET request on the aggreggated session health endpoint