### PR TITLE
Fix: HA & Demux - Audio Increment Not Respecting Position Diff-Threshold

### DIFF
--- a/spec/engine/session_spec.js
+++ b/spec/engine/session_spec.js
@@ -18,7 +18,7 @@ describe("Session", () => {
     expect(id1).not.toEqual(id2);
   });
 
-  fit("for demuxed, returns the appropriate audio increment value", async () => {
+  it("for demuxed, returns the appropriate audio increment value when desync is within acceptable limit", async () => {
     const session = new Session("dummy", null, sessionLiveStore);
     const mockFinalAudioIdx = 50; // current Vod has 50 media sequences to serve.
     const mockCurrentVideoPosition = 200.0 * 1000; // Video is 200s deep into its content.
@@ -27,66 +27,70 @@ describe("Session", () => {
       const mockPositions = [196.0, 199.84, 203.68, 207.52];
       return mockPositions[pos_n_current - mockMseqAudio];
     };
-    const output = await session._determineAudioIncrement(
+    const output = await session._determineExtraMediaIncrement(
+      "audio",
       mockCurrentVideoPosition,
       mockFinalAudioIdx,
       mockMseqAudio,
       mock_getAudioPlayheadPosition,
       24
     );
-    expect(output).toBe(1);
+    expect(output.increment).toBe(1);
   });
 
-  fit("for demuxed, returns the appropriate audio increment value", async () => {
+  it("for demuxed, returns the appropriate audio increment value when they are in sync but there is a floating point error", async () => {
     const session = new Session("dummy", null, sessionLiveStore);
-    const mockFinalAudioIdx = 50; // current Vod has 50 media sequences to serve.
-    const mockCurrentVideoPosition = 441.7599999999981697 * 1000; // Video is 200s deep into its content.
-    const mockMseqAudio = 25; // current mseq for audio on vod, 25 out of 50.
+    const mockFinalAudioIdx = 50;
+    const mockCurrentVideoPosition = 441.7599999999981697 * 1000; 
+    const mockMseqAudio = 25;
     const mock_getAudioPlayheadPosition = async (pos_n_current) => {
       const mockPositions = [437.919999999999, 441.75999999999897];
       return mockPositions[pos_n_current - mockMseqAudio];
     };
-    const output = await session._determineAudioIncrement(
+    const output = await session._determineExtraMediaIncrement(
+      "audio",
       mockCurrentVideoPosition,
       mockFinalAudioIdx,
       mockMseqAudio,
       mock_getAudioPlayheadPosition,
       24
     );
-    expect(output).toBe(1);
+    expect(output.increment).toBe(1);
   });
-  fit("for demuxed, returns the appropriate audio increment value", async () => {
+  it("for demuxed, returns the appropriate audio increment value, normal case I", async () => {
     const session = new Session("dummy", null, sessionLiveStore);
-    const mockFinalAudioIdx = 50; // current Vod has 50 media sequences to serve.
-    const mockCurrentVideoPosition = 3.840 * 8 * 1000; // Video is 200s deep into its content.
-    const mockMseqAudio = 5; // current mseq for audio on vod, 25 out of 50.
+    const mockFinalAudioIdx = 50;
+    const mockCurrentVideoPosition = 3.840 * 8 * 1000;
+    const mockMseqAudio = 5;
     const mock_getAudioPlayheadPosition = async (pos_n_current) => {
       const mockPositions = [0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52];
       return mockPositions[pos_n_current];
     };
-    const output = await session._determineAudioIncrement(
+    const output = await session._determineExtraMediaIncrement(
+      "audio",
       mockCurrentVideoPosition,
       mockFinalAudioIdx,
       mockMseqAudio,
       mock_getAudioPlayheadPosition
     );
-    expect(output).toBe(3);
+    expect(output.increment).toBe(3);
   });
-  fit("for demuxed, returns the appropriate audio increment value", async () => {
+  it("for demuxed, returns the appropriate audio increment value, normal case II", async () => {
     const session = new Session("dummy", null, sessionLiveStore);
-    const mockFinalAudioIdx = 50; // current Vod has 50 media sequences to serve.
-    const mockCurrentVideoPosition = 14 * 1000; // Video is 200s deep into its content.
-    const mockMseqAudio = 0; // current mseq for audio on vod, 25 out of 50.
+    const mockFinalAudioIdx = 50;
+    const mockCurrentVideoPosition = 14 * 1000;
+    const mockMseqAudio = 0;
     const mock_getAudioPlayheadPosition = async (pos_n_current) => {
       const mockPositions = [0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52];
       return mockPositions[pos_n_current];
     };
-    const output = await session._determineAudioIncrement(
+    const output = await session._determineExtraMediaIncrement(
+      "subtitle",
       mockCurrentVideoPosition,
       mockFinalAudioIdx,
       mockMseqAudio,
       mock_getAudioPlayheadPosition
     );
-    expect(output).toBe(4);
+    expect(output.increment).toBe(4);
   });
 });

--- a/spec/engine/session_spec.js
+++ b/spec/engine/session_spec.js
@@ -1,20 +1,92 @@
-const Session = require('../../engine/session.js');
+const Session = require("../../engine/session.js");
 
-const { SessionStateStore } = require('../../engine/session_state.js');
-const { PlayheadStateStore } = require('../../engine/playhead_state.js');
+const { SessionStateStore } = require("../../engine/session_state.js");
+const { PlayheadStateStore } = require("../../engine/playhead_state.js");
 
 describe("Session", () => {
   let sessionLiveStore = undefined;
   beforeEach(() => {
     sessionLiveStore = {
       sessionStateStore: new SessionStateStore(),
-      playheadStateStore: new PlayheadStateStore()
-    };  
+      playheadStateStore: new PlayheadStateStore(),
+    };
   });
 
   it("creates a unique session ID", () => {
-    const id1 = new Session('dummy', null, sessionLiveStore).sessionId;
-    const id2 = new Session('dummy', null, sessionLiveStore).sessionId;
+    const id1 = new Session("dummy", null, sessionLiveStore).sessionId;
+    const id2 = new Session("dummy", null, sessionLiveStore).sessionId;
     expect(id1).not.toEqual(id2);
+  });
+
+  fit("for demuxed, returns the appropriate audio increment value", async () => {
+    const session = new Session("dummy", null, sessionLiveStore);
+    const mockFinalAudioIdx = 50; // current Vod has 50 media sequences to serve.
+    const mockCurrentVideoPosition = 200.0 * 1000; // Video is 200s deep into its content.
+    const mockMseqAudio = 25; // current mseq for audio on vod, 25 out of 50.
+    const mock_getAudioPlayheadPosition = async (pos_n_current) => {
+      const mockPositions = [196.0, 199.84, 203.68, 207.52];
+      return mockPositions[pos_n_current - mockMseqAudio];
+    };
+    const output = await session._determineAudioIncrement(
+      mockCurrentVideoPosition,
+      mockFinalAudioIdx,
+      mockMseqAudio,
+      mock_getAudioPlayheadPosition,
+      24
+    );
+    expect(output).toBe(1);
+  });
+
+  fit("for demuxed, returns the appropriate audio increment value", async () => {
+    const session = new Session("dummy", null, sessionLiveStore);
+    const mockFinalAudioIdx = 50; // current Vod has 50 media sequences to serve.
+    const mockCurrentVideoPosition = 441.7599999999981697 * 1000; // Video is 200s deep into its content.
+    const mockMseqAudio = 25; // current mseq for audio on vod, 25 out of 50.
+    const mock_getAudioPlayheadPosition = async (pos_n_current) => {
+      const mockPositions = [437.919999999999, 441.75999999999897];
+      return mockPositions[pos_n_current - mockMseqAudio];
+    };
+    const output = await session._determineAudioIncrement(
+      mockCurrentVideoPosition,
+      mockFinalAudioIdx,
+      mockMseqAudio,
+      mock_getAudioPlayheadPosition,
+      24
+    );
+    expect(output).toBe(1);
+  });
+  fit("for demuxed, returns the appropriate audio increment value", async () => {
+    const session = new Session("dummy", null, sessionLiveStore);
+    const mockFinalAudioIdx = 50; // current Vod has 50 media sequences to serve.
+    const mockCurrentVideoPosition = 3.840 * 8 * 1000; // Video is 200s deep into its content.
+    const mockMseqAudio = 5; // current mseq for audio on vod, 25 out of 50.
+    const mock_getAudioPlayheadPosition = async (pos_n_current) => {
+      const mockPositions = [0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52];
+      return mockPositions[pos_n_current];
+    };
+    const output = await session._determineAudioIncrement(
+      mockCurrentVideoPosition,
+      mockFinalAudioIdx,
+      mockMseqAudio,
+      mock_getAudioPlayheadPosition
+    );
+    expect(output).toBe(3);
+  });
+  fit("for demuxed, returns the appropriate audio increment value", async () => {
+    const session = new Session("dummy", null, sessionLiveStore);
+    const mockFinalAudioIdx = 50; // current Vod has 50 media sequences to serve.
+    const mockCurrentVideoPosition = 14 * 1000; // Video is 200s deep into its content.
+    const mockMseqAudio = 0; // current mseq for audio on vod, 25 out of 50.
+    const mock_getAudioPlayheadPosition = async (pos_n_current) => {
+      const mockPositions = [0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52];
+      return mockPositions[pos_n_current];
+    };
+    const output = await session._determineAudioIncrement(
+      mockCurrentVideoPosition,
+      mockFinalAudioIdx,
+      mockMseqAudio,
+      mock_getAudioPlayheadPosition
+    );
+    expect(output).toBe(4);
   });
 });

--- a/spec/engine/session_spec.js
+++ b/spec/engine/session_spec.js
@@ -18,7 +18,7 @@ describe("Session", () => {
     expect(id1).not.toEqual(id2);
   });
 
-  it("for demuxed, returns the appropriate audio increment value when desync is within acceptable limit", async () => {
+  it("for demuxed, returns the appropriate audio increment value when desync is within acceptable limit, case I", async () => {
     const session = new Session("dummy", null, sessionLiveStore);
     const mockFinalAudioIdx = 50; // current Vod has 50 media sequences to serve.
     const mockCurrentVideoPosition = 200.0 * 1000; // Video is 200s deep into its content.
@@ -36,6 +36,26 @@ describe("Session", () => {
       24
     );
     expect(output.increment).toBe(1);
+  });
+
+  it("for demuxed, returns the appropriate audio increment value when desync is within acceptable limit, case II", async () => {
+    const session = new Session("dummy", null, sessionLiveStore);
+    const mockFinalAudioIdx = 50; // current Vod has 50 media sequences to serve.
+    const mockCurrentVideoPosition = 200.0 * 1000; // Video is 200s deep into its content.
+    const mockMseqAudio = 25; // current mseq for audio on vod, 25 out of 50.
+    const mock_getAudioPlayheadPosition = async (pos_n_current) => {
+      const mockPositions = [192.16, 196.0, 199.84, 203.68, 207.52];
+      return mockPositions[pos_n_current - mockMseqAudio];
+    };
+    const output = await session._determineExtraMediaIncrement(
+      "audio",
+      mockCurrentVideoPosition,
+      mockFinalAudioIdx,
+      mockMseqAudio,
+      mock_getAudioPlayheadPosition,
+      24
+    );
+    expect(output.increment).toBe(2);
   });
 
   it("for demuxed, returns the appropriate audio increment value when they are in sync but there is a floating point error", async () => {


### PR DESCRIPTION
When dealing with source demuxed vods which have video segment lengths longer than the audio counterparts, the CE is to increment the media sequence for the audio playhead position so that it is always further into the content than video, ie "fast forwarding" in a sense.
eg.  If the current playhead position for video is 296 secs and audio is 291.84 secs, then audio would need to increment further until the audio position is >= video position. 
However, there is a diff threshold set to 0.250s. This means that if the difference between the positions is below 0.250, then the CE is happy with the current positions. The difference should be insignificant for most players and the video segment should be able to be paired with the audio segment.
The issue is though that CE still increments by 2 even though it should be happy with one. This is caused by a mistake in a do-while loop.

This PR fixes this by refactoring the audio increment loop, replacing it with a new function and unit tests to validate its expected behaviors. The new function will also be used to calculate the increment value for subtitles, given that the subtitle delta positions are correct. 