### PR TITLE
chore: update hls-vodtolive to version 4.1.3

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -348,9 +348,10 @@ class Session {
     if (id) {
       await this._sessionStateStore.reset(id);
       await this._playheadStateStore.reset(id);
+    } else {
+      await this._sessionStateStore.resetAll();
+      await this._playheadStateStore.resetAll();
     }
-    await this._sessionStateStore.resetAll();
-    await this._playheadStateStore.resetAll();
   }
 
   async getSessionState() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@eyevinn/hls-repeat": "^0.2.0",
         "@eyevinn/hls-truncate": "^0.3.0",
-        "@eyevinn/hls-vodtolive": "^4.1.1",
-        "@eyevinn/m3u8": "^0.5.3",
+        "@eyevinn/hls-vodtolive": "^4.1.3",
+        "@eyevinn/m3u8": "^0.5.8",
         "abort-controller": "^3.0.0",
         "debug": "^3.2.7",
         "ioredis": "^5.3.2",
@@ -97,11 +97,11 @@
       }
     },
     "node_modules/@eyevinn/hls-vodtolive": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-4.1.1.tgz",
-      "integrity": "sha512-TgAwYSwNYh6nPHxBKMPsS3DFAfVUO2vbbCB9r7sRvxOTEn6qIaNMOgL2fYl+OQjXG9gJAMrcFOTRMUDvQZ/HpQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-4.1.3.tgz",
+      "integrity": "sha512-8Uh+WhqngbEeIIb3FlJwCGKOUv3lBDFRCHneyW0l0DknzlHXKhMZHdxvTyT1SeI6FHvacDWLv1EgT0ICcgL8Cg==",
       "dependencies": {
-        "@eyevinn/m3u8": "^0.5.6",
+        "@eyevinn/m3u8": "^0.5.8",
         "abort-controller": "^3.0.0",
         "debug": "^4.1.1",
         "node-fetch": "2.6.7"
@@ -148,9 +148,9 @@
       }
     },
     "node_modules/@eyevinn/m3u8": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.6.tgz",
-      "integrity": "sha512-aYWN9Rzofs3MCuoGrJww6vExnKg8bLHN2jAmzjK8t/akwT3bzwR3i2kqH895ZysR87mikgOzF3IaBp4OYYfwWg==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.8.tgz",
+      "integrity": "sha512-fmCfznP8XUPhJa5zRu+6H8Ys/ts/1J4wj0on1yIUSnkf+UTW2NciWxoB24EDe3s8eF2qjcyMNnwU/DeIM7+f6A==",
       "dependencies": {
         "chunked-stream": "~0.0.2"
       }
@@ -2844,11 +2844,11 @@
       }
     },
     "@eyevinn/hls-vodtolive": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-4.1.1.tgz",
-      "integrity": "sha512-TgAwYSwNYh6nPHxBKMPsS3DFAfVUO2vbbCB9r7sRvxOTEn6qIaNMOgL2fYl+OQjXG9gJAMrcFOTRMUDvQZ/HpQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-4.1.3.tgz",
+      "integrity": "sha512-8Uh+WhqngbEeIIb3FlJwCGKOUv3lBDFRCHneyW0l0DknzlHXKhMZHdxvTyT1SeI6FHvacDWLv1EgT0ICcgL8Cg==",
       "requires": {
-        "@eyevinn/m3u8": "^0.5.6",
+        "@eyevinn/m3u8": "^0.5.8",
         "abort-controller": "^3.0.0",
         "debug": "^4.1.1",
         "node-fetch": "2.6.7"
@@ -2878,9 +2878,9 @@
       }
     },
     "@eyevinn/m3u8": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.6.tgz",
-      "integrity": "sha512-aYWN9Rzofs3MCuoGrJww6vExnKg8bLHN2jAmzjK8t/akwT3bzwR3i2kqH895ZysR87mikgOzF3IaBp4OYYfwWg==",
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@eyevinn/m3u8/-/m3u8-0.5.8.tgz",
+      "integrity": "sha512-fmCfznP8XUPhJa5zRu+6H8Ys/ts/1J4wj0on1yIUSnkf+UTW2NciWxoB24EDe3s8eF2qjcyMNnwU/DeIM7+f6A==",
       "requires": {
         "chunked-stream": "~0.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "dependencies": {
     "@eyevinn/hls-repeat": "^0.2.0",
     "@eyevinn/hls-truncate": "^0.3.0",
-    "@eyevinn/hls-vodtolive": "^4.1.1",
-    "@eyevinn/m3u8": "^0.5.3",
+    "@eyevinn/hls-vodtolive": "^4.1.3",
+    "@eyevinn/m3u8": "^0.5.8",
     "abort-controller": "^3.0.0",
     "debug": "^3.2.7",
     "ioredis": "^5.3.2",


### PR DESCRIPTION
With this bump to the `@eyevinn/hls-vodtolive` lib, this PR can have CE accommodate the feature requested in #208.

NOTE - For this to work you will need:
- to couple CE with the `@eyevinn/lambda-stitch` ^v0.2.4 when serving vod URLs to the engine. 
- to enable PDT timestamps. You can do so by letting the assetManager adapter insert a UNIX timestamp in the field `unixTs` of the returned vod item in the response for assetManager function `getNextVod()`