### PR TITLE
Fix: Reduce redis roundtrips

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -702,12 +702,12 @@ class Session {
 
   async incrementAsync() {
     await this._tickAsync();
-    const isLeader = await this._sessionStateStore.isLeader(this._instanceId);
+    // Reuse state from _tickAsync instead of re-reading from Redis
+    const { sessionState: tickSessionState, isLeader, currentVod: tickCurrentVod } = this._lastTickState;
+    let sessionState = tickSessionState;
+    let currentVod = tickCurrentVod;
 
-    let sessionState = await this._sessionState.getValues(
-      ["state", "mediaSeq", "mediaSeqAudio", "mediaSeqSubtitle", "discSeq", "discSeqAudio", "discSeqSubtitle", "vodMediaSeqVideo", "vodMediaSeqAudio", "vodMediaSeqSubtitle"]);
     let playheadState = await this._playheadState.getValues(["mediaSeq", "mediaSeqAudio", "mediaSeqSubtitle", "vodMediaSeqVideo", "vodMediaSeqAudio", "vodMediaSubtitle", "playheadRef"]);
-    let currentVod = await this._sessionState.getCurrentVod();
     if (!currentVod ||
       sessionState.vodMediaSeqVideo === null ||
       sessionState.vodMediaSeqAudio === null ||
@@ -724,6 +724,7 @@ class Session {
       }
       return null;
     }
+    let newSessionState = {};
     if (sessionState.state === SessionState.VOD_NEXT_INITIATING || sessionState.state === SessionState.VOD_RELOAD_INITIATING) {
       if (isLeader) {
         const isOldVod = this._isOldVod(playheadState.playheadRef, currentVod.getDuration());
@@ -746,46 +747,54 @@ class Session {
         this.isAllowedToClearVodCache = true;
       }
     } else {
-      sessionState.vodMediaSeqVideo = await this._sessionState.increment("vodMediaSeqVideo", 1);
+      // Compute increments locally instead of individual Redis round-trips
+      if (isLeader) {
+        debug(`[${this._sessionId}]: I am incrementing key vodMediaSeqVideo with 1`);
+        sessionState.vodMediaSeqVideo += 1;
+      }
       let playheadPosVideoMs;
       let playheadAudio;
       let playheadSubtitle;
-      
+
       playheadPosVideoMs = (await this._getCurrentPlayheadPosition()) * 1000;
 
       if (this.use_demuxed_audio) {
         const audioSeqLastIdx = currentVod.getLiveMediaSequencesCount("audio") - 1;
-        const sessionStateObj = await this._sessionState.getValues(["vodMediaSeqAudio"]);
         playheadAudio = await this._determineExtraMediaIncrement(
           "audio",
           playheadPosVideoMs,
           audioSeqLastIdx,
-          sessionStateObj.vodMediaSeqAudio,
+          sessionState.vodMediaSeqAudio,
           this._getAudioPlayheadPosition.bind(this)
         );
-        // Perform the Increment
         debug(`[${this._sessionId}]: Will increment audio with ${playheadAudio.increment}`);
-        sessionState.vodMediaSeqAudio = await this._sessionState.increment("vodMediaSeqAudio", playheadAudio.increment);
+        if (isLeader) {
+          debug(`[${this._sessionId}]: I am incrementing key vodMediaSeqAudio with ${playheadAudio.increment}`);
+          sessionState.vodMediaSeqAudio += (playheadAudio.increment === 0 ? 0 : playheadAudio.increment || 1);
+        }
       }
       if (this.use_vtt_subtitles) {
-        const playheadPosVideo = playheadPosVideo || (await this._getCurrentPlayheadPosition()) * 1000;
         const subtitleSeqLastIdx = currentVod.getLiveMediaSequencesCount("subtitle") - 1;
-        const sessionStateObj = await this._sessionState.getValues(["vodMediaSeqSubtitle"]);
         playheadSubtitle = await this._determineExtraMediaIncrement(
           "subtitle",
           playheadPosVideoMs,
           subtitleSeqLastIdx,
-          sessionStateObj.vodMediaSeqSubtitle,
+          sessionState.vodMediaSeqSubtitle,
           this._getSubtitlePlayheadPosition.bind(this)
         );
-        // Perform the Increment
         debug(`[${this._sessionId}]: Will increment subtitle with ${playheadSubtitle.increment}`);
-        sessionState.vodMediaSeqSubtitle = await this._sessionState.increment("vodMediaSeqSubtitle", playheadSubtitle.increment);
+        if (isLeader) {
+          debug(`[${this._sessionId}]: I am incrementing key vodMediaSeqSubtitle with ${playheadSubtitle.increment}`);
+          sessionState.vodMediaSeqSubtitle += (playheadSubtitle.increment === 0 ? 0 : playheadSubtitle.increment || 1);
+        }
       }
       this._logCurrentPlayheadPositions(playheadPosVideoMs, playheadAudio, playheadSubtitle);
-    }
 
-    let newSessionState = {};
+      // Include locally-computed increments in the batch write
+      newSessionState.vodMediaSeqVideo = sessionState.vodMediaSeqVideo;
+      newSessionState.vodMediaSeqAudio = sessionState.vodMediaSeqAudio;
+      newSessionState.vodMediaSeqSubtitle = sessionState.vodMediaSeqSubtitle;
+    }
     if (sessionState.vodMediaSeqVideo >= currentVod.getLiveMediaSequencesCount() - 1) {
       newSessionState.vodMediaSeqVideo = currentVod.getLiveMediaSequencesCount() - 1;
       newSessionState.state = SessionState.VOD_NEXT_INIT;
@@ -804,20 +813,25 @@ class Session {
       this.isSwitchingBackToV2L = false;
     }
 
-    const updatedValues = await this._sessionState.setValues(newSessionState);
-    sessionState = { ...sessionState, ...updatedValues };
-
     if (isLeader) {
       debug(`[${this._sessionId}]: I am the leader, updating PlayheadState values`);
     }
-    const updatedPlayhead = await this._playheadState.setValues({
+
+    // Playhead values are derived from local sessionState — no read-after-write dependency
+    // on the session setValues result, so we can run both writes in parallel
+    const playheadData = {
       "mediaSeq": sessionState.mediaSeq,
       "mediaSeqAudio": sessionState.mediaSeqAudio,
       "mediaSeqSubtitle": sessionState.mediaSeqSubtitle,
       "vodMediaSeqVideo": sessionState.vodMediaSeqVideo,
       "vodMediaSeqAudio": sessionState.vodMediaSeqAudio,
       "vodMediaSeqSubtitle": sessionState.vodMediaSeqSubtitle
-    }, isLeader);
+    };
+    const [updatedValues, updatedPlayhead] = await Promise.all([
+      this._sessionState.setValues(newSessionState),
+      this._playheadState.setValues(playheadData, isLeader)
+    ]);
+    sessionState = { ...sessionState, ...updatedValues };
     playheadState = { ...playheadState, ...updatedPlayhead };
 
     if (currentVod.sequenceAlwaysContainNewSegments) {
@@ -1243,6 +1257,7 @@ class Session {
       sessionState.state = SessionState.VOD_INIT;
     }
 
+    try {
     switch (sessionState.state) {
       case SessionState.VOD_INIT:
       case SessionState.VOD_INIT_BY_ID:
@@ -1359,6 +1374,9 @@ class Session {
             debug("No slate to load");
             throw err;
           }
+          // Re-read sessionState after _insertSlate modified it in Redis
+          sessionState = await this._sessionState.getValues(
+            ["state", "assetId", "vodMediaSeqVideo", "vodMediaSeqAudio", "vodMediaSeqSubtitle", "mediaSeq", "mediaSeqAudio", "mediaSeqSubtitle", "discSeq", "discSeqAudio", "discSeqSubtitle", "nextVod"]);
         }
       case SessionState.VOD_PLAYING:
         if (isLeader) {
@@ -1579,6 +1597,9 @@ class Session {
             debug("No slate to load");
             throw err;
           }
+          // Re-read sessionState after _insertSlate modified it in Redis
+          sessionState = await this._sessionState.getValues(
+            ["state", "assetId", "vodMediaSeqVideo", "vodMediaSeqAudio", "vodMediaSeqSubtitle", "mediaSeq", "mediaSeqAudio", "mediaSeqSubtitle", "discSeq", "discSeqAudio", "discSeqSubtitle", "nextVod"]);
           // Allow Leader|Follower to clear vodCache...
           this.isAllowedToClearVodCache = true;
         }
@@ -1711,6 +1732,9 @@ class Session {
               channel: this._sessionId,
               reqTimeMs: Date.now() - startTS,
             });
+            // Re-read sessionState after individual set() calls modified it in Redis
+            sessionState = await this._sessionState.getValues(
+              ["state", "assetId", "vodMediaSeqVideo", "vodMediaSeqAudio", "vodMediaSeqSubtitle", "mediaSeq", "mediaSeqAudio", "mediaSeqSubtitle", "discSeq", "discSeqAudio", "discSeqSubtitle", "nextVod"]);
             return;
           } else {
             debug(`[${this._sessionId}]: not a leader so will go directly to state VOD_RELOAD_INITIATING`);
@@ -1736,6 +1760,10 @@ class Session {
         return;
       default:
         throw new Error("Invalid state: " + sessionState.state);
+    }
+    } finally {
+      // Store tick state for incrementAsync to reuse, avoiding redundant Redis reads
+      this._lastTickState = { sessionState, isLeader, currentVod };
     }
   }
 

--- a/spec/engine/ha_spec.js
+++ b/spec/engine/ha_spec.js
@@ -1,0 +1,364 @@
+const Session = require('../../engine/session.js');
+const m3u8 = require('@eyevinn/m3u8');
+const Readable = require('stream').Readable;
+
+const { SessionStateStore } = require('../../engine/session_state.js');
+const { PlayheadStateStore } = require('../../engine/playhead_state.js');
+
+class TestAssetManager {
+  constructor(opts, assets) {
+    this.assets = [
+      { id: 1, title: "Tears of Steel", uri: "https://maitv-vod.lab.eyevinn.technology/tearsofsteel_4k.mov/master.m3u8" },
+      { id: 2, title: "VINN", uri: "https://maitv-vod.lab.eyevinn.technology/VINN.mp4/master.m3u8" }
+    ];
+    if (assets) {
+      this.assets = assets;
+    }
+    this.pos = 0;
+    this.doFail = false;
+    if (opts && opts.fail) {
+      this.doFail = true;
+    }
+  }
+  getNextVod(vodRequest) {
+    return new Promise((resolve, reject) => {
+      if (this.doFail) {
+        reject("should fail");
+      } else {
+        const vod = this.assets[this.pos++];
+        if (this.pos > this.assets.length - 1) {
+          this.pos = 0;
+        }
+        resolve(vod);
+      }
+    });
+  }
+}
+
+const parseMediaManifest = async (manifest) => {
+  const parser = m3u8.createStream();
+  const m3u = await new Promise((resolve, reject) => {
+    let manifestStream = new Readable();
+    manifestStream.push(manifest);
+    manifestStream.push(null);
+    manifestStream.pipe(parser);
+    parser.on('m3u', m3u => {
+      resolve(m3u);
+    });
+  });
+  return m3u;
+};
+
+describe("High Availability", () => {
+  describe("Leader-Follower with shared state", () => {
+    let sessionStateStore;
+    let playheadStateStore;
+
+    beforeEach(() => {
+      sessionStateStore = new SessionStateStore();
+      playheadStateStore = new PlayheadStateStore();
+    });
+
+    it("leader writes state that follower can read", async () => {
+      const assetMgr = new TestAssetManager();
+      const leaderStore = {
+        sessionStateStore,
+        playheadStateStore,
+        instanceId: "leader-instance",
+      };
+      const followerStore = {
+        sessionStateStore,
+        playheadStateStore,
+        instanceId: "follower-instance",
+      };
+
+      // Leader session inits first — becomes the leader
+      const leaderSession = new Session(assetMgr, { sessionId: '1' }, leaderStore);
+      await leaderSession.initAsync();
+
+      // Follower session shares same sessionId and stores
+      const followerSession = new Session(assetMgr, { sessionId: '1' }, followerStore);
+      await followerSession.initAsync();
+
+      // Leader increments — should write state
+      await leaderSession.incrementAsync();
+      const leaderManifest = await leaderSession.getCurrentMediaManifestAsync(180000);
+      expect(leaderManifest).not.toBeNull();
+
+      // Follower increments — should read leader's state, not write
+      await followerSession.incrementAsync();
+      const followerManifest = await followerSession.getCurrentMediaManifestAsync(180000);
+      expect(followerManifest).not.toBeNull();
+
+      // Both should produce valid manifests
+      const leaderM3u = await parseMediaManifest(leaderManifest);
+      const followerM3u = await parseMediaManifest(followerManifest);
+      expect(leaderM3u.get('mediaSequence')).toBeDefined();
+      expect(followerM3u.get('mediaSequence')).toBeDefined();
+    });
+
+    it("follower does not overwrite leader's vodMediaSeqVideo", async () => {
+      const assetMgr = new TestAssetManager();
+      const leaderStore = {
+        sessionStateStore,
+        playheadStateStore,
+        instanceId: "leader-instance",
+      };
+      const followerStore = {
+        sessionStateStore,
+        playheadStateStore,
+        instanceId: "follower-instance",
+      };
+
+      const leaderSession = new Session(assetMgr, { sessionId: '1' }, leaderStore);
+      await leaderSession.initAsync();
+
+      const followerSession = new Session(assetMgr, { sessionId: '1' }, followerStore);
+      await followerSession.initAsync();
+
+      // Leader advances several times
+      for (let i = 0; i < 5; i++) {
+        await leaderSession.incrementAsync();
+      }
+
+      // Read the shared state directly — leader incremented 5 times
+      const stateAfterLeader = await sessionStateStore.get('1', 'vodMediaSeqVideo');
+      expect(stateAfterLeader).toEqual(5);
+
+      // Follower increments — should NOT change vodMediaSeqVideo in store
+      // (follower reads but doesn't write via setValues since isLeader=false)
+      await followerSession.incrementAsync();
+      const stateAfterFollower = await sessionStateStore.get('1', 'vodMediaSeqVideo');
+      expect(stateAfterFollower).toEqual(5); // Follower must not overwrite leader's value
+    });
+
+    it("leader and follower media sequences stay monotonically increasing", async () => {
+      const assetMgr = new TestAssetManager();
+      const leaderStore = {
+        sessionStateStore,
+        playheadStateStore,
+        instanceId: "leader-instance",
+      };
+      const followerStore = {
+        sessionStateStore,
+        playheadStateStore,
+        instanceId: "follower-instance",
+      };
+
+      const leaderSession = new Session(assetMgr, { sessionId: '1' }, leaderStore);
+      await leaderSession.initAsync();
+      const followerSession = new Session(assetMgr, { sessionId: '1' }, followerStore);
+      await followerSession.initAsync();
+
+      let lastLeaderMseq = -1;
+      let lastFollowerMseq = -1;
+
+      for (let i = 0; i < 20; i++) {
+        const leaderManifest = await leaderSession.incrementAsync();
+        if (leaderManifest) {
+          const lm = leaderManifest.match(/#EXT-X-MEDIA-SEQUENCE:(\d+)/);
+          if (lm) {
+            const mseq = Number(lm[1]);
+            expect(mseq).toBeGreaterThanOrEqual(lastLeaderMseq);
+            lastLeaderMseq = mseq;
+          }
+        }
+
+        const followerManifest = await followerSession.incrementAsync();
+        if (followerManifest) {
+          const fm = followerManifest.match(/#EXT-X-MEDIA-SEQUENCE:(\d+)/);
+          if (fm) {
+            const mseq = Number(fm[1]);
+            expect(mseq).toBeGreaterThanOrEqual(lastFollowerMseq);
+            lastFollowerMseq = mseq;
+          }
+        }
+      }
+
+      // Both should have progressed
+      expect(lastLeaderMseq).toBeGreaterThan(0);
+      expect(lastFollowerMseq).toBeGreaterThan(0);
+    });
+  });
+
+  describe("_lastTickState consistency", () => {
+    let sessionStore;
+
+    beforeEach(() => {
+      sessionStore = {
+        sessionStateStore: new SessionStateStore(),
+        playheadStateStore: new PlayheadStateStore(),
+        instanceId: "test-instance",
+      };
+    });
+
+    it("_lastTickState is populated after incrementAsync", async () => {
+      const assetMgr = new TestAssetManager();
+      const session = new Session(assetMgr, { sessionId: '1' }, sessionStore);
+      await session.initAsync();
+      await session.incrementAsync();
+
+      expect(session._lastTickState).toBeDefined();
+      expect(session._lastTickState.sessionState).toBeDefined();
+      expect(session._lastTickState.isLeader).toBe(true);
+      expect(session._lastTickState.currentVod).toBeDefined();
+    });
+
+    it("_lastTickState reflects correct state after VOD transition", async () => {
+      const assetMgr = new TestAssetManager(null, [
+        { id: 1, title: "Short", uri: "https://maitv-vod.lab.eyevinn.technology/VINN.mp4/master.m3u8" }
+      ]);
+      const session = new Session(assetMgr, { sessionId: '1' }, sessionStore);
+      await session.initAsync();
+
+      let lastState = null;
+      // Run enough increments to cross a VOD boundary
+      for (let i = 0; i < 20; i++) {
+        await session.incrementAsync();
+        lastState = session._lastTickState;
+      }
+
+      expect(lastState.sessionState).toBeDefined();
+      expect(lastState.currentVod).not.toBeNull();
+      // vodMediaSeqVideo should be a valid non-negative number
+      expect(lastState.sessionState.vodMediaSeqVideo).toBeGreaterThanOrEqual(0);
+    });
+
+    it("_lastTickState has correct state after slate insertion", async () => {
+      const assetMgr = new TestAssetManager({ fail: true });
+      const session = new Session(assetMgr, {
+        sessionId: '1',
+        slateUri: 'http://testcontent.eyevinn.technology/slates/ottera/playlist.m3u8'
+      }, sessionStore);
+      await session.initAsync();
+
+      await session.incrementAsync();
+
+      // After slate insertion + incrementAsync processing, _lastTickState should have valid state
+      expect(session._lastTickState).toBeDefined();
+      expect(session._lastTickState.sessionState).toBeDefined();
+      expect(session._lastTickState.currentVod).not.toBeNull();
+      // State is VOD_PLAYING (2) because incrementAsync detects VOD_NEXT_INITIATING
+      // from _tickAsync and transitions it to VOD_PLAYING
+      expect(session._lastTickState.sessionState.state).toEqual(2); // VOD_PLAYING
+    });
+  });
+});
+
+describe("Concurrent ticks", () => {
+  let sessionStateStore;
+  let playheadStateStore;
+
+  beforeEach(() => {
+    sessionStateStore = new SessionStateStore();
+    playheadStateStore = new PlayheadStateStore();
+  });
+
+  it("multiple channels ticking concurrently do not corrupt each other's state", async () => {
+    const channels = [];
+    const numChannels = 4;
+
+    for (let i = 0; i < numChannels; i++) {
+      const assetMgr = new TestAssetManager();
+      const store = {
+        sessionStateStore,
+        playheadStateStore,
+        instanceId: "instance-1",
+      };
+      const session = new Session(assetMgr, { sessionId: `ch-${i}` }, store);
+      await session.initAsync();
+      channels.push(session);
+    }
+
+    // Tick all channels concurrently for several rounds
+    for (let round = 0; round < 10; round++) {
+      await Promise.all(channels.map(ch => ch.incrementAsync()));
+    }
+
+    // Each channel should have valid, independent state
+    for (let i = 0; i < numChannels; i++) {
+      const manifest = await channels[i].getCurrentMediaManifestAsync(180000);
+      expect(manifest).not.toBeNull();
+
+      const m = manifest.match(/#EXT-X-MEDIA-SEQUENCE:(\d+)/);
+      expect(m).not.toBeNull();
+      const mseq = Number(m[1]);
+      // Each channel started at 0 and ticked 10 times
+      expect(mseq).toBeGreaterThanOrEqual(10);
+    }
+  });
+
+  it("concurrent ticks produce monotonically increasing media sequences per channel", async () => {
+    const numChannels = 3;
+    const channels = [];
+    const lastMseqs = new Array(numChannels).fill(-1);
+
+    for (let i = 0; i < numChannels; i++) {
+      const assetMgr = new TestAssetManager();
+      const store = {
+        sessionStateStore,
+        playheadStateStore,
+        instanceId: "instance-1",
+      };
+      const session = new Session(assetMgr, { sessionId: `concurrent-${i}` }, store);
+      await session.initAsync();
+      channels.push(session);
+    }
+
+    for (let round = 0; round < 15; round++) {
+      const results = await Promise.all(channels.map(ch => ch.incrementAsync()));
+
+      for (let i = 0; i < numChannels; i++) {
+        if (results[i]) {
+          const m = results[i].match(/#EXT-X-MEDIA-SEQUENCE:(\d+)/);
+          if (m) {
+            const mseq = Number(m[1]);
+            if (lastMseqs[i] >= 0) {
+              expect(mseq).toBeGreaterThanOrEqual(lastMseqs[i]);
+            }
+            lastMseqs[i] = mseq;
+          }
+        }
+      }
+    }
+
+    // All channels should have progressed
+    for (let i = 0; i < numChannels; i++) {
+      expect(lastMseqs[i]).toBeGreaterThan(0);
+    }
+  });
+
+  it("concurrent ticks across a VOD switch produce valid manifests", async () => {
+    const numChannels = 3;
+    const channels = [];
+
+    for (let i = 0; i < numChannels; i++) {
+      // Short VOD to force VOD switches
+      const assetMgr = new TestAssetManager(null, [
+        { id: 1, title: "Short", uri: "https://maitv-vod.lab.eyevinn.technology/VINN.mp4/master.m3u8" }
+      ]);
+      const store = {
+        sessionStateStore,
+        playheadStateStore,
+        instanceId: "instance-1",
+      };
+      const session = new Session(assetMgr, { sessionId: `vodswitch-${i}` }, store);
+      await session.initAsync();
+      channels.push(session);
+    }
+
+    let errorCount = 0;
+    for (let round = 0; round < 20; round++) {
+      const results = await Promise.all(channels.map(ch => ch.incrementAsync()));
+      for (const manifest of results) {
+        if (manifest) {
+          // Verify it's parseable HLS
+          const hasHeader = manifest.includes('#EXTM3U');
+          if (!hasHeader) errorCount++;
+        }
+      }
+    }
+
+    expect(errorCount).toBe(0);
+  });
+});


### PR DESCRIPTION
 ## Summary

  This PR reduces Redis I/O in the session tick path by reusing state already loaded in `_tickAsync`, computing sequence increments locally, and batching
  independent writes in parallel.

  It also adds focused test coverage for HA leader/follower behavior, `_lastTickState` consistency, and concurrent ticking across multiple channels.

  ## What changed

  - Reuse `_lastTickState` in `incrementAsync()` instead of re-reading session state and current VOD from Redis after every tick
  - Replace per-field Redis `increment()` calls with local sequence calculations when the instance is leader
  - Run session state and playhead state writes in parallel with `Promise.all()` where there is no read-after-write dependency
  - Re-read session state only in the few flows where `_tickAsync()` mutates Redis indirectly, such as slate insertion and VOD reload transitions
  - Add HA specs covering leader/follower state isolation and monotonic media sequence progression
  - Add concurrent tick specs covering multiple channels and VOD transitions under parallel load

  ## Why

  Before this change, a normal tick could trigger roughly 9 Redis round-trips. Most of that work was redundant because the needed state had already been
  loaded earlier in the same tick.

  This change reduces the steady-state tick path to roughly 2-4 Redis round-trips, which should lower Redis load and reduce tick latency without changing
  session behavior.

  ## Behavior and safety

  - Preserves leader-only write semantics
  - Keeps follower instances reading shared state without overwriting leader progress
  - Maintains monotonic media sequence progression across normal playback, VOD switches, and slate insertion
  - Adds regression coverage for the paths that now rely on `_lastTickState`

  ## Testing

  - Added HA coverage in `spec/engine/ha_spec.js`
  - Covers:
    - leader/follower shared-state behavior
    - follower not overwriting leader `vodMediaSeqVideo`
    - `_lastTickState` consistency after normal ticks, VOD transitions, and slate insertion
    - concurrent multi-channel ticking with monotonic media sequence checks
    - concurrent VOD switching producing valid manifests