### PR TITLE
ci: update publish workflows to Node 20 and actions v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,5 @@
 name: Publish
-  
+
 on:
   release:
     types: [released]
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: |
-          npm install
+          npm ci
           npm run build
           npm publish
         env:

--- a/.github/workflows/rc.yml
+++ b/.github/workflows/rc.yml
@@ -1,5 +1,5 @@
 name: Publish release candidate
-  
+
 on:
   release:
     types: [prereleased]
@@ -9,13 +9,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: |
-          npm install
+          npm ci
           npm run build
           npm publish --tag rc
         env:


### PR DESCRIPTION
## Summary
- Update `publish.yml` and `rc.yml` from `actions/checkout@v1` + `actions/setup-node@v1` (Node 16) to `@v4` (Node 20)
- Switch `npm install` to `npm ci` for reproducible builds
- Fixes the 5.1.0 publish failure caused by Node 16 being incompatible with the package's `engines: { node: ">=20" }` requirement

## Context
The publish workflow for v5.1.0 failed with E403 because the checkout grabbed a stale `package.json` version (5.0.6). The Node 16 runtime also triggered EBADENGINE warnings for multiple dependencies. This PR ensures future releases build and publish correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)