### PR TITLE
fix: bump hls-vodtolive to 4.1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@eyevinn/hls-repeat": "^0.3.0",
         "@eyevinn/hls-truncate": "^0.4.0",
-        "@eyevinn/hls-vodtolive": "^4.1.9",
+        "@eyevinn/hls-vodtolive": "^4.1.10",
         "@eyevinn/m3u8": "^0.5.6",
         "@fastify/static": "^9.1.1",
         "abort-controller": "^3.0.0",
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@eyevinn/hls-vodtolive": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-4.1.9.tgz",
-      "integrity": "sha512-k0WQ3WFLHECqvw1x8Dwe2j3wcY46AVGs7wBg2hZXPLWSFN4qZl/kobyl/DG2zakgLnhBxUGwrLa4otwXJn+Eiw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-4.1.10.tgz",
+      "integrity": "sha512-4MearhD0KNsASziw4tRcEU3F/B8W0qoYG4F8OFdu8KQiRmR95uNNizit6H/qBXba0+JlCvDEymPMwd4GOzfQQA==",
       "license": "MIT",
       "dependencies": {
         "@eyevinn/m3u8": "^0.5.8",
@@ -2907,9 +2907,9 @@
       }
     },
     "@eyevinn/hls-vodtolive": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-4.1.9.tgz",
-      "integrity": "sha512-k0WQ3WFLHECqvw1x8Dwe2j3wcY46AVGs7wBg2hZXPLWSFN4qZl/kobyl/DG2zakgLnhBxUGwrLa4otwXJn+Eiw==",
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@eyevinn/hls-vodtolive/-/hls-vodtolive-4.1.10.tgz",
+      "integrity": "sha512-4MearhD0KNsASziw4tRcEU3F/B8W0qoYG4F8OFdu8KQiRmR95uNNizit6H/qBXba0+JlCvDEymPMwd4GOzfQQA==",
       "requires": {
         "@eyevinn/m3u8": "^0.5.8",
         "abort-controller": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -26,12 +26,15 @@
     "Nicholas Frederiksen <nicholas.frederiksen@eyevinn.se> (Eyevinn Technology AB)",
     "Johan Lautakoski <johan.lautakoski@eyevinn.se> (Eyevinn Technology AB)"
   ],
-  "repository": "https://github.com/Eyevinn/channel-engine",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Eyevinn/channel-engine.git"
+  },
   "license": "Apache-2.0",
   "dependencies": {
     "@eyevinn/hls-repeat": "^0.3.0",
     "@eyevinn/hls-truncate": "^0.4.0",
-    "@eyevinn/hls-vodtolive": "^4.1.9",
+    "@eyevinn/hls-vodtolive": "^4.1.10",
     "@eyevinn/m3u8": "^0.5.6",
     "@fastify/static": "^9.1.1",
     "abort-controller": "^3.0.0",


### PR DESCRIPTION
## Summary
- Bumps `@eyevinn/hls-vodtolive` from `4.1.9` to `4.1.10`
- Picks up fix for audio segment doubling when a VOD with multiple audio languages is loaded after a VOD with a single audio language via `loadAfter()` (https://github.com/Eyevinn/hls-vodtolive/pull/137)

## Test plan
- [x] Fix verified in hls-vodtolive (171 specs, 0 failures)
- [x] Verify channel-engine CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)