### PR TITLE
fix: bind to 0.0.0.0 for Fastify 5 compatibility

### DIFF
--- a/engine/server.ts
+++ b/engine/server.ts
@@ -579,7 +579,7 @@ export class ChannelEngine {
   }
 
   listen(port) {
-    this.server.listen({ port: port }, (err) => {
+    this.server.listen({ port: port, host: '0.0.0.0' }, (err) => {
       if (err) {
         console.error(err);
         process.exit(1);


### PR DESCRIPTION
## Summary
- Fastify 5 changed the default `listen()` host from `0.0.0.0` to `127.0.0.1`
- In containerized environments (Docker/ECS behind ALB), this prevents all external traffic from reaching the server — health checks fail and containers restart in a loop
- Fix: explicitly pass `host: '0.0.0.0'` to `server.listen()`

## Test plan
- [x] TypeScript compiles cleanly
- [x] All 64 specs pass (0 failures, 7 pending)
- [x] Verified Fastify 5 binds to `127.0.0.1` without fix, `0.0.0.0` with fix
- [x] Deploy to staging and verify ALB health checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)