### PR TITLE
Fix follower's currentVod cache staleness during VOD swap

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -1414,11 +1414,17 @@ class Session {
           }
         } else {
           // Handle edge case where Leader loaded next vod but Follower remained in state=VOD_PLAYING
-          if ((this.prevMediaSeqOffset.video !== null) & (sessionState.mediaSeq !== this.prevMediaSeqOffset.video)) {
+          if ((this.prevMediaSeqOffset.video !== null) && (sessionState.mediaSeq !== this.prevMediaSeqOffset.video)) {
             debug(`[${this._sessionId}]: state=VOD_PLAYING, current[${sessionState.vodMediaSeqVideo}], prev[${this.prevVodMediaSeq.video}], total[${currentVod.getLiveMediaSequencesCount()}]`);
             debug(`[${this._sessionId}]: mediaSeq offsets -> current[${sessionState.vodMediaSeqVideo}], prev[${this.prevVodMediaSeq.video}]`);
-            // Allow Follower to clear VodCache...
-            this.isAllowedToClearVodCache = true;
+            // Eagerly refresh currentVod so _lastTickState and subsequent INCREMENT log see the new VOD.
+            // Without this, the follower's currentVod stays stale for one tick after a VOD swap.
+            await this._sessionState.clearCurrentVodCache();
+            currentVod = await this._sessionState.getCurrentVod();
+            this.prevVodMediaSeq.video = sessionState.vodMediaSeqVideo;
+            this.prevVodMediaSeq.audio = sessionState.vodMediaSeqAudio;
+            this.prevVodMediaSeq.subtitle = sessionState.vodMediaSeqSubtitle;
+            this.prevMediaSeqOffset.video = sessionState.mediaSeq;
           }
         }
         debug(`[${this._sessionId}]: state=VOD_PLAYING (${sessionState.vodMediaSeqVideo}_${sessionState.vodMediaSeqAudio}_${sessionState.vodMediaSeqSubtitle}, ${currentVod.getLiveMediaSequencesCount()}_${currentVod.getLiveMediaSequencesCount("audio")}_${currentVod.getLiveMediaSequencesCount("subtitle")})`);

--- a/spec/engine/ha_spec.js
+++ b/spec/engine/ha_spec.js
@@ -179,6 +179,47 @@ describe("High Availability", () => {
       expect(lastLeaderMseq).toBeGreaterThan(0);
       expect(lastFollowerMseq).toBeGreaterThan(0);
     });
+
+    it("follower's currentVod tracks leader across VOD transitions (regression: stale cache after redis-roundtrip optimization)", async () => {
+      // Two VODs with different segment counts so a stale-cache regression is observable
+      // as a mismatch between leader.getLiveMediaSequencesCount() and follower.getLiveMediaSequencesCount()
+      const assetMgr = new TestAssetManager(null, [
+        { id: 1, title: "Tears of Steel", uri: "https://maitv-vod.lab.eyevinn.technology/tearsofsteel_4k.mov/master.m3u8" },
+        { id: 2, title: "VINN", uri: "https://maitv-vod.lab.eyevinn.technology/VINN.mp4/master.m3u8" }
+      ]);
+      const leaderStore = {
+        sessionStateStore,
+        playheadStateStore,
+        instanceId: "leader-instance",
+      };
+      const followerStore = {
+        sessionStateStore,
+        playheadStateStore,
+        instanceId: "follower-instance",
+      };
+
+      const leaderSession = new Session(assetMgr, { sessionId: 'vod-swap' }, leaderStore);
+      await leaderSession.initAsync();
+      const followerSession = new Session(assetMgr, { sessionId: 'vod-swap' }, followerStore);
+      await followerSession.initAsync();
+
+      // Drive both through enough ticks to cross a VOD boundary.
+      // After each tick, the follower's local currentVod must report the same
+      // total as the leader's — if it diverges, _tickAsync stored a stale
+      // currentVod in _lastTickState and the next manifest would have wrong totals.
+      for (let i = 0; i < 30; i++) {
+        await leaderSession.incrementAsync();
+        await followerSession.incrementAsync();
+
+        const leaderVod = leaderSession._lastTickState && leaderSession._lastTickState.currentVod;
+        const followerVod = followerSession._lastTickState && followerSession._lastTickState.currentVod;
+        if (!leaderVod || !followerVod) continue;
+
+        const leaderTotal = leaderVod.getLiveMediaSequencesCount();
+        const followerTotal = followerVod.getLiveMediaSequencesCount();
+        expect(followerTotal).toEqual(leaderTotal);
+      }
+    });
   });
 
   describe("_lastTickState consistency", () => {


### PR DESCRIPTION
## Summary

Followers can serve manifests with stale segment-count totals for one tick (~3s) after a VOD swap. This regression appeared after the redis round-trip reduction in #344 (shipped in v5.0.6).

## Root cause

The follower's `_tickAsync` VOD_PLAYING path only set `isAllowedToClearVodCache = true` and deferred the actual cache clear to `incrementAsync`. But `_lastTickState` is frozen at the end of `_tickAsync` — so `_lastTickState.currentVod` reflects the **previous** VOD, and the immediately-following INCREMENT log + manifest use stale totals.

Pre-5.0.6, the follower's `incrementAsync` did 5+ Redis round-trips via `_sessionState.increment(...)` calls. Each `await` yielded to the event loop, giving HTTP request handlers (which call `getCurrentMediaAndDiscSequenceCount` → `clearCurrentVodCache`) a chance to invalidate the cache between ticks. After #344 removed those round-trips, the implicit synchronization point disappeared.

## Evidence from prod CloudWatch

**5.0.4 transition (May 10):**
```
FOLLOWER state=VOD_NEXT_INITIATING (65_64_64, 66_66_66)
LEADER   INCREMENT (0_0_0 of 51_51_51)
FOLLOWER state=VOD_PLAYING (0_0_0, 51_51_51)   ← fresh total
FOLLOWER INCREMENT (0_0_0 of 51_51_51)         ← fresh total
```

**5.0.6 transition (May 12, same channel):**
```
FOLLOWER state=VOD_NEXT_INITIATING (79_78_78, 80_80_80)
LEADER   INCREMENT (0_0_0 of 76_76_76)
FOLLOWER state=VOD_PLAYING (0_0_0, 80_80_80)   ← STALE total
FOLLOWER INCREMENT (0_0_0 of 80_80_80)         ← STALE total
[~3s later]
FOLLOWER state=VOD_PLAYING (1_0_0, 76_76_76)   ← finally fresh
```

## Fix

Mirror the leader's existing path (`engine/session.js:1407-1414`): eagerly clear the cache and re-read `currentVod` inside `_tickAsync` when the follower detects a `mediaSeq` offset change. Also update `prevVodMediaSeq` and `prevMediaSeqOffset` so the detection logic doesn't fire repeatedly.

Drive-by: fix the bitwise `&` typo to logical `&&` on the condition.

## Trade-off

Adds one extra Redis read per VOD transition on the follower (once every ~5-30 minutes per channel). Negligible cost. Maintains all the optimization wins from #344 for the leader's hot path.

## Test plan

- [x] All existing specs pass (`npm test` — 65 specs, 0 failures)
- [x] Added a leader/follower coherency regression spec in `ha_spec.js` that compares `_lastTickState.currentVod` totals across ticks
- [ ] Verify in prod via CloudWatch logs after deploy that follower's first VOD_PLAYING log after a transition shows fresh totals

🤖 Generated with [Claude Code](https://claude.com/claude-code)