### PR TITLE
Fix audio/subtitle lagging 1 segment behind video after redis optimization

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -756,7 +756,11 @@ class Session {
       let playheadAudio;
       let playheadSubtitle;
 
-      playheadPosVideoMs = (await this._getCurrentPlayheadPosition()) * 1000;
+      // Pass the locally-updated vodMediaSeqVideo (leader incremented above) so
+      // playhead position reflects this tick's video segment, not the stale
+      // value still in Redis. Without this, audio/subtitle stay 1 segment
+      // behind video for the entire VOD lifetime.
+      playheadPosVideoMs = (await this._getCurrentPlayheadPosition(sessionState.vodMediaSeqVideo)) * 1000;
 
       if (this.use_demuxed_audio) {
         const audioSeqLastIdx = currentVod.getLiveMediaSequencesCount("audio") - 1;
@@ -2068,12 +2072,21 @@ class Session {
     return 0;
   }
 
-  async _getCurrentPlayheadPosition() {
-    const sessionState = await this._sessionState.getValues(["vodMediaSeqVideo"]);
+  async _getCurrentPlayheadPosition(overrideVodMediaSeqVideo) {
+    // Caller can pass the in-progress local vodMediaSeqVideo to avoid the Redis
+    // round-trip and the race where the leader has incremented its local value
+    // but hasn't written it to Redis yet (incrementAsync writes happen later via
+    // a parallel Promise.all). Falling back to Redis preserves the old behavior
+    // for callers like startPlayheadAsync that run after incrementAsync.
+    let vodMediaSeqVideo = overrideVodMediaSeqVideo;
+    if (vodMediaSeqVideo === undefined) {
+      const sessionState = await this._sessionState.getValues(["vodMediaSeqVideo"]);
+      vodMediaSeqVideo = sessionState.vodMediaSeqVideo;
+    }
     const currentVod = await this._sessionState.getCurrentVod();
     const playheadPositions = currentVod.getPlayheadPositions();
-    debug(`[${this._sessionId}]: Current playhead position (${sessionState.vodMediaSeqVideo}): ${roundToThreeDecimals(playheadPositions[sessionState.vodMediaSeqVideo])}`);
-    return playheadPositions[sessionState.vodMediaSeqVideo];
+    debug(`[${this._sessionId}]: Current playhead position (${vodMediaSeqVideo}): ${roundToThreeDecimals(playheadPositions[vodMediaSeqVideo])}`);
+    return playheadPositions[vodMediaSeqVideo];
   }
 
   async _getAudioPlayheadPosition(seqIdx) {


### PR DESCRIPTION
## Summary

After #344 replaced `_sessionState.increment(\"vodMediaSeqVideo\", 1)` with a local `sessionState.vodMediaSeqVideo += 1` (and deferred the Redis write to a parallel `Promise.all` later in `incrementAsync`), `_getCurrentPlayheadPosition()` reads a stale `vodMediaSeqVideo` from Redis. The stale `positionV` flows into `_determineExtraMediaIncrement` and causes the loop to break with `increment=0`, so audio/subtitle never advance on the same tick as video. The 1-segment offset persists for the entire VOD lifetime.

## Evidence from CloudWatch (same channel, same query, different days)

**2026-04-28 (5.0.4, pre-#344) — tracks synchronized:**
```
INCREMENT (27_27_27 of 61_61_61)
INCREMENT (28_28_28 of 61_61_61)
INCREMENT (29_29_29 of 61_61_61)
INCREMENT (30_30_30 of 61_61_61)
```

**2026-05-12 (5.0.6, post-#344) — video permanently 1 ahead:**
```
INCREMENT (2_1_1 of 76_76_76)
INCREMENT (3_2_2 of 76_76_76)
INCREMENT (4_3_3 of 76_76_76)
INCREMENT (5_4_4 of 76_76_76)
```

## Fix

Let `_getCurrentPlayheadPosition` accept an optional override so callers in the increment flow can pass the locally-updated `vodMediaSeqVideo` instead of reading the (stale) Redis value. Other callers (e.g. `startPlayheadAsync`, which runs after `incrementAsync` writes) fall back to reading Redis — preserving the existing behavior there.


## Related

Companion to #351 — both PRs address regressions caused by #344's redis-roundtrip reduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)