### PR TITLE
feat: add event boolean option to Session/engine config

### DIFF
--- a/engine/server.ts
+++ b/engine/server.ts
@@ -66,6 +66,7 @@ export interface ChannelEngineOpts {
   sessionEventStream?: boolean;
   sessionHealthKey?: string;
   rollingPDT?: boolean;
+  event?: boolean;
 }
 
 interface StreamerOpts {
@@ -501,7 +502,8 @@ export class ChannelEngine {
         slateDuration: channel.slate && channel.slate.duration ? channel.slate.duration : this.slateDuration,
         cloudWatchMetrics: this.logCloudWatchMetrics,
         sessionEventStream: options.sessionEventStream,
-        rollingPDT: options.rollingPDT
+        rollingPDT: options.rollingPDT,
+        event: options.event
       }, this.sessionStore);
 
       sessionsLive[channel.id] = new SessionLive({

--- a/engine/session.js
+++ b/engine/session.js
@@ -88,6 +88,7 @@ class Session {
     this.currentPlayheadRef = null;
     this.disableLegacyMasterManifestFormat = null;
     this.rollingPDT = null;
+    this.event = false;
     if (config) {
       if (config.alwaysNewSegments) {
         this.alwaysNewSegments = config.alwaysNewSegments;
@@ -100,6 +101,9 @@ class Session {
       }
       if (config.rollingPDT) {
         this.rollingPDT = config.rollingPDT;
+      }
+      if (config.event) {
+        this.event = config.event;
       }
       if (config.alwaysMapBandwidthByNearest) {
         this.alwaysMapBandwidthByNearest = config.alwaysMapBandwidthByNearest;

--- a/spec/engine/session_spec.js
+++ b/spec/engine/session_spec.js
@@ -18,6 +18,18 @@ describe("Session", () => {
     expect(id1).not.toEqual(id2);
   });
 
+  it("sets the event flag when configured with { event: true }", () => {
+    const session = new Session("dummy", { event: true }, sessionLiveStore);
+    expect(session.event).toEqual(true);
+  });
+
+  it("defaults the event flag to false when not configured", () => {
+    const sessionNoConfig = new Session("dummy", null, sessionLiveStore);
+    const sessionEmptyConfig = new Session("dummy", {}, sessionLiveStore);
+    expect(sessionNoConfig.event).toEqual(false);
+    expect(sessionEmptyConfig.event).toEqual(false);
+  });
+
   it("for demuxed, returns the appropriate audio increment value when desync is within acceptable limit, case I", async () => {
     const session = new Session("dummy", null, sessionLiveStore);
     const mockFinalAudioIdx = 50; // current Vod has 50 media sequences to serve.


### PR DESCRIPTION
## Summary
- Implements #361: introduces and plumbs a new `{ event: true }` boolean option so a session can be configured as an event stream. Foundational sub-issue of the event-stream chain (broken out from #109) — it only plumbs the flag and does **not** change any manifest output or add behaviour keyed off the flag yet.

## Changes
- `engine/session.js` — default `this.event = false` in the Session constructor config block (alongside `alwaysNewSegments`/`rollingPDT`); assign from config when provided.
- `engine/server.ts` — added `event?: boolean` to the `ChannelEngineOpts` interface and threaded `event: options.event` into the `new Session(...)` config, mirroring `rollingPDT`.
- `spec/engine/session_spec.js` — two focused jasmine specs: flag set when `{ event: true }`; defaults `false` for `null`/`{}` config.

## Test plan
- PROOF: `npm ci` → clean install
- PROOF: `npm run build` (`tsc --project ./`) → exit 0 (typechecks with the new interface field)
- PROOF: `npm test` (jasmine) → `66 specs, 0 failures, 7 pending` (the 7 pending are pre-existing `xit` specs, unrelated)
- PROOF: `npx jasmine spec/engine/session_spec.js` → `8 specs, 0 failures` (the 2 new event specs run and pass)

Acceptance criteria all hold: `{ event: true }` yields `session.event === true`; omitted defaults to `false`; flag is inert when off so existing behaviour is unchanged.

Closes #361

🤖 Automated via Channel Engine Dev daily-backlog-pr skill