### PR TITLE
feat: append EXT-X-ENDLIST to media playlists when event stream ends

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -1807,6 +1807,23 @@ class Session {
    * This is detection only — deciding what the session does with the signal is
    * handled by the caller (and, later, ENDLIST emission by #363).
    */
+  /**
+   * Append #EXT-X-ENDLIST to a served media playlist when, in event mode, the
+   * schedule has ended (issue #363). Returns the manifest unchanged otherwise, so
+   * the tag never appears while content is still playing or when event mode is off.
+   * Idempotent: never adds a second ENDLIST if one is already present.
+   */
+  _appendEndlistIfEnded(m3u8) {
+    if (!m3u8 || !this.event || !this.isEndOfSchedule) {
+      return m3u8;
+    }
+    if (/#EXT-X-ENDLIST/.test(m3u8)) {
+      return m3u8;
+    }
+    const separator = m3u8.endsWith("\n") ? "" : "\n";
+    return m3u8 + separator + "#EXT-X-ENDLIST\n";
+  }
+
   _isEndOfScheduleSignal(nextVod) {
     if (!nextVod) {
       return true;
@@ -2424,6 +2441,11 @@ class Session {
         );
         this.prevVodMediaSeq[variantType] = playheadState[MSDKeys.vodMediaSeq];
         this.prevMediaSeqOffset[variantType] = playheadState[MSDKeys.mediaSeq];
+        // In event mode, once the schedule has ended (issue #363) terminate the
+        // served media playlist with #EXT-X-ENDLIST so players stop reloading.
+        // Applied uniformly to video, demuxed-audio and subtitle variants. The tag
+        // is never appended while content is still playing (isEndOfSchedule=false).
+        m3u8 = this._appendEndlistIfEnded(m3u8);
         return m3u8;
       } catch (err) {
         logerror(this._sessionId, err);

--- a/spec/engine/session_spec.js
+++ b/spec/engine/session_spec.js
@@ -84,6 +84,44 @@ describe("Session", () => {
     });
   });
 
+  describe("EXT-X-ENDLIST on served media playlists (event mode, issue #363)", () => {
+    // A served media playlist ends its last line with a newline (segment lines are
+    // "\n"-terminated by the vod lib), so ENDLIST is appended on its own line.
+    const mediaPlaylist =
+      "#EXTM3U\n#EXT-X-VERSION:6\n#EXT-X-TARGETDURATION:6\n#EXTINF:6.0,\nseg0.ts\n";
+
+    it("appends #EXT-X-ENDLIST once the schedule has ended in event mode", () => {
+      const session = new Session("dummy", { event: true }, sessionLiveStore);
+      session.isEndOfSchedule = true;
+      const out = session._appendEndlistIfEnded(mediaPlaylist);
+      expect(out.endsWith("#EXT-X-ENDLIST\n")).toEqual(true);
+    });
+
+    it("does not append #EXT-X-ENDLIST while content is still playing in event mode", () => {
+      const session = new Session("dummy", { event: true }, sessionLiveStore);
+      expect(session.isEndOfSchedule).toEqual(false);
+      const out = session._appendEndlistIfEnded(mediaPlaylist);
+      expect(out).toEqual(mediaPlaylist);
+      expect(/#EXT-X-ENDLIST/.test(out)).toEqual(false);
+    });
+
+    it("never appends #EXT-X-ENDLIST when event mode is off, even at end of schedule", () => {
+      const session = new Session("dummy", null, sessionLiveStore);
+      session.isEndOfSchedule = true; // even if forced, off-mode never emits the tag
+      const out = session._appendEndlistIfEnded(mediaPlaylist);
+      expect(/#EXT-X-ENDLIST/.test(out)).toEqual(false);
+    });
+
+    it("is idempotent and does not add a second #EXT-X-ENDLIST", () => {
+      const session = new Session("dummy", { event: true }, sessionLiveStore);
+      session.isEndOfSchedule = true;
+      const once = session._appendEndlistIfEnded(mediaPlaylist);
+      const twice = session._appendEndlistIfEnded(once);
+      expect(twice).toEqual(once);
+      expect((twice.match(/#EXT-X-ENDLIST/g) || []).length).toEqual(1);
+    });
+  });
+
   it("for demuxed, returns the appropriate audio increment value when desync is within acceptable limit, case I", async () => {
     const session = new Session("dummy", null, sessionLiveStore);
     const mockFinalAudioIdx = 50; // current Vod has 50 media sequences to serve.


### PR DESCRIPTION
## Summary
- Implements #363: append `#EXT-X-ENDLIST` to served media playlists once an event-mode schedule ends.

## Changes
- Add `_appendEndlistIfEnded(m3u8)` helper in `engine/session.js`: returns the manifest unchanged unless `this.event && this.isEndOfSchedule`; appends a single `#EXT-X-ENDLIST` line (idempotent, newline-safe).
- Call it at the single manifest-assembly point `_getM3u8File(...)`, so it applies uniformly to video, demuxed-audio and subtitle variants.
- Uses the existing end-of-schedule signal (`isEndOfSchedule`, set in `_getNextVod` for event mode) scaffolded by #362, so the tag is never emitted while content is still playing or when event mode is off.
- Minimal spec coverage added; the comprehensive post-ENDLIST session behaviour suite is #364's scope.

## Test plan
- PROOF: `npm run build` → clean (`tsc --project ./ && cp ./package.json dist/`, no errors)
- PROOF: `npm test` → `76 specs, 0 failures, 7 pending specs` (baseline 72; +4 new specs)

Closes #363

🤖 Automated via Channel Engine Dev daily-backlog-pr skill