### PR TITLE
feat: back off stream-switch polling during an ongoing event and speed up near its end

### DIFF
--- a/engine/server.ts
+++ b/engine/server.ts
@@ -466,10 +466,15 @@ export class ChannelEngine {
           const ts_1 = Date.now();
           await this.updateStreamSwitchAsync()
           const ts_2 = Date.now();
-          const  interval = (timeIntervalMs - (ts_2 - ts_1)) < 0 ? minIntervalMs : (timeIntervalMs - (ts_2 - ts_1)); 
+          // Adaptive cadence: back off while all active channels are mid-event and
+          // speed up as any channel nears its end. The poll loop is global but event
+          // state is per-channel, so we take the MINIMUM interval required across all
+          // channels — never under-polling a channel that needs responsiveness.
+          const desiredIntervalMs = this.computeStreamSwitchIntervalMs(timeIntervalMs);
+          const  interval = (desiredIntervalMs - (ts_2 - ts_1)) < 0 ? minIntervalMs : (desiredIntervalMs - (ts_2 - ts_1));
           const tickInterval = await WTG.getWaitTime(interval);
           await timer(tickInterval)
-          debug(`StreamSwitchLoop waited for all channels. Next tick in: ${tickInterval}ms`)
+          debug(`StreamSwitchLoop waited for all channels. Next tick in: ${tickInterval}ms (desired base=${desiredIntervalMs}ms)`)
         } catch (err) {
           console.error(err)
           debug(`StreamSwitchLoop iteration failed. Trying Again in 1000ms!`);
@@ -480,6 +485,41 @@ export class ChannelEngine {
     if (this.streamSwitchManager) {
       StreamSwitchLoop(this.streamSwitchTimeIntervalMs);
     }
+  }
+
+  // Compute the desired next poll interval for the global StreamSwitchLoop from the
+  // aggregated per-channel event state. Because the loop is global but event state is
+  // per-channel, the result is the MINIMUM interval any channel requires so we never
+  // under-poll a channel that needs responsiveness:
+  //   - a channel that is near-end contributes the fast near-end interval;
+  //   - a channel that is mid-event but not near-end contributes the slower ongoing
+  //     interval;
+  //   - a channel with no ongoing event contributes the base interval.
+  // The loop uses the minimum across all channels. When no channel reports an ongoing
+  // event (no schedule / no ongoing event) this falls back to the base interval,
+  // keeping behavior identical to today.
+  computeStreamSwitchIntervalMs(baseIntervalMs) {
+    const channels = Object.keys(sessionSwitchers);
+    let desiredMs = baseIntervalMs;
+    for (const channel of channels) {
+      const switcher = sessionSwitchers[channel];
+      if (!switcher || typeof switcher.getEventPollingState !== "function") {
+        continue;
+      }
+      const state = switcher.getEventPollingState();
+      let channelMs;
+      if (state.nearEnd) {
+        channelMs = this.streamSwitchNearEndEventIntervalMs;
+      } else if (state.midEvent) {
+        channelMs = this.streamSwitchOngoingEventIntervalMs;
+      } else {
+        channelMs = baseIntervalMs;
+      }
+      if (channelMs < desiredMs) {
+        desiredMs = channelMs;
+      }
+    }
+    return desiredMs;
   }
 
   async updateStreamSwitchAsync() {

--- a/engine/stream_switcher.js
+++ b/engine/stream_switcher.js
@@ -54,6 +54,39 @@ class StreamSwitcher {
     return this.eventId;
   }
 
+  /**
+   * Report this channel's event-polling state, used by the global StreamSwitchLoop
+   * to pick an adaptive poll cadence without leaking switcher internals.
+   *
+   * "Mid-event"/ongoing (per #365): the switcher is on a live stream
+   * (this.streamTypeLive === true) and the current scheduleObj is within its
+   * window, i.e. now >= start_time && now < end_time.
+   *
+   * "Near end": an ongoing event whose remaining time is within the switcher's
+   * existing end-of-event guard window (end_time - now <= 10000; see the 10000ms
+   * guard in streamSwitcher()). Derived from that guard rather than a new constant.
+   *
+   * @returns {{ midEvent: boolean, nearEnd: boolean, msUntilEnd: (number|null) }}
+   *   msUntilEnd is null when there is no ongoing event.
+   */
+  getEventPollingState() {
+    const NEAR_END_GUARD_MS = 10000;
+    const scheduleObj = this.timeDiff;
+    if (!this.streamTypeLive || !scheduleObj || scheduleObj.end_time == null || scheduleObj.start_time == null) {
+      return { midEvent: false, nearEnd: false, msUntilEnd: null };
+    }
+    const now = Date.now();
+    if (now < scheduleObj.start_time || now >= scheduleObj.end_time) {
+      return { midEvent: false, nearEnd: false, msUntilEnd: null };
+    }
+    const msUntilEnd = scheduleObj.end_time - now;
+    return {
+      midEvent: true,
+      nearEnd: msUntilEnd <= NEAR_END_GUARD_MS,
+      msUntilEnd,
+    };
+  }
+
   async abortLiveFeed(session, sessionLive, message) {
     if (this.streamTypeLive) {
       let status = null;

--- a/spec/engine/stream_switcher_spec.js
+++ b/spec/engine/stream_switcher_spec.js
@@ -565,3 +565,94 @@ describe("The Stream Switcher", () => {
     expect(newList).toEqual(result);
   });
 });
+
+describe("The Stream Switcher adaptive poll cadence (#366)", () => {
+  const tsNow2 = Date.now();
+  // Mirror of Server.computeStreamSwitchIntervalMs(): pick the MINIMUM interval any
+  // channel requires from each switcher's getEventPollingState(). Kept here so the
+  // aggregation rule is exercised against real StreamSwitcher instances without
+  // standing up a full Server/TypeScript build in the jasmine specs.
+  const computeInterval = (switchers, cfg) => {
+    let desiredMs = cfg.base;
+    for (const s of switchers) {
+      const state = s.getEventPollingState();
+      let channelMs;
+      if (state.nearEnd) {
+        channelMs = cfg.nearEnd;
+      } else if (state.midEvent) {
+        channelMs = cfg.ongoing;
+      } else {
+        channelMs = cfg.base;
+      }
+      if (channelMs < desiredMs) {
+        desiredMs = channelMs;
+      }
+    }
+    return desiredMs;
+  };
+  const CFG = { base: 3000, ongoing: 3000, nearEnd: 1000 };
+
+  beforeEach(() => {
+    jasmine.clock().install();
+    jasmine.clock().mockDate(new Date(tsNow2));
+  });
+  afterEach(() => {
+    jasmine.clock().uninstall();
+  });
+
+  const midEventSwitcher = () => {
+    const s = new StreamSwitcher({ streamSwitchManager: new TestSwitchManager(0) });
+    s.streamTypeLive = true;
+    s.timeDiff = { start_time: tsNow2 - 30 * 1000, end_time: tsNow2 + 60 * 1000 };
+    return s;
+  };
+  const nearEndSwitcher = () => {
+    const s = new StreamSwitcher({ streamSwitchManager: new TestSwitchManager(0) });
+    s.streamTypeLive = true;
+    s.timeDiff = { start_time: tsNow2 - 60 * 1000, end_time: tsNow2 + 5 * 1000 };
+    return s;
+  };
+
+  it("reports no ongoing event when there is no schedule / not live => base interval", () => {
+    const s = new StreamSwitcher({ streamSwitchManager: new TestSwitchManager(0) });
+    // Not live, no scheduleObj tracked yet.
+    const state = s.getEventPollingState();
+    expect(state.midEvent).toBe(false);
+    expect(state.nearEnd).toBe(false);
+    expect(state.msUntilEnd).toBe(null);
+    expect(computeInterval([s], CFG)).toBe(CFG.base);
+  });
+
+  it("backs off to the ongoing interval while mid-event and not near end", () => {
+    const s = midEventSwitcher();
+    const state = s.getEventPollingState();
+    expect(state.midEvent).toBe(true);
+    expect(state.nearEnd).toBe(false);
+    expect(state.msUntilEnd).toBe(60 * 1000);
+    expect(computeInterval([s], CFG)).toBe(CFG.ongoing);
+  });
+
+  it("speeds up to the near-end interval as end_time comes within the 10000ms guard", () => {
+    const s = midEventSwitcher();
+    expect(s.getEventPollingState().nearEnd).toBe(false);
+    // Advance until only 5s remain of the event => within the 10000ms near-end guard.
+    jasmine.clock().tick(55 * 1000);
+    const state = s.getEventPollingState();
+    expect(state.midEvent).toBe(true);
+    expect(state.nearEnd).toBe(true);
+    expect(state.msUntilEnd).toBe(5 * 1000);
+    expect(computeInterval([s], CFG)).toBe(CFG.nearEnd);
+  });
+
+  it("takes the minimum interval across channels (one near-end pulls the loop fast)", () => {
+    const ongoing = midEventSwitcher();
+    const nearEnd = nearEndSwitcher();
+    // All-ongoing => back off.
+    expect(computeInterval([ongoing, midEventSwitcher()], CFG)).toBe(CFG.ongoing);
+    // Any near-end => the whole loop drops to the fast near-end interval.
+    expect(computeInterval([ongoing, nearEnd], CFG)).toBe(CFG.nearEnd);
+    // Any channel with no ongoing event keeps the base/fast interval too.
+    const idle = new StreamSwitcher({ streamSwitchManager: new TestSwitchManager(0) });
+    expect(computeInterval([ongoing, idle], CFG)).toBe(CFG.base);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements #366: adaptive stream-switch poll cadence, wiring up the config surface added in #365.

## Changes
- `engine/stream_switcher.js`: add `getEventPollingState()` → `{ midEvent, nearEnd, msUntilEnd }`, derived from `streamTypeLive` + the current `scheduleObj` (`this.timeDiff`). "Mid-event" = live and within the window; "near-end" = `end_time - now <= 10000` (reuses the switcher's existing 10000ms end-of-event guard, no new constant). Returns idle when not live / outside the window, so stale schedule state after a switch-back is handled.
- `engine/server.ts`: add `computeStreamSwitchIntervalMs(base)` — aggregates per-channel state and returns the MINIMUM interval any channel requires (near-end→fast, mid-event→ongoing, else→base), so the single global loop never under-polls a channel that needs responsiveness. Feeds the result into the existing `WaitTimeGenerator`/timer path, preserving the 50ms floor and elapsed-time subtraction. Falls back to base when no channel has an ongoing event (behavior identical to today).

## Test plan
- PROOF: `npm run build` → clean (no errors)
- PROOF: `npm test` → `83 specs, 0 failures, 7 pending specs` (baseline 79; +4 specs in `spec/engine/stream_switcher_spec.js` covering no-schedule, mid-event back-off, near-end speed-up, and multi-channel min aggregation)

Closes #366

🤖 Automated via Channel Engine Dev daily-backlog-pr skill