### PR TITLE
feat: add ad-break/interstitial channel configuration surface

### DIFF
--- a/engine/server.ts
+++ b/engine/server.ts
@@ -29,10 +29,39 @@ const eventStreams = {};
 const DefaultDummySubtitleEndpointPath = "/dummyUrl"
 const DefaultSubtitleSpliceEndpointPath = "/sliceUrl"
 
+// Configuration for SGAI HLS-interstitial ad breaks. Config surface only for
+// now (issue #367): this describes when/where a channel may open an ad break
+// and which slate to fall back to. No interstitial tags are emitted from this
+// config yet — that lands in a follow-up (#368). Defaults to disabled.
+export interface AdBreakOpts {
+  // Master enable/disable flag for interstitial ad breaks on the channel.
+  // When false (the default) no ad-break plumbing is active.
+  enabled: boolean;
+  // URL of the ad-serving endpoint queried to fill an interstitial break.
+  // Required and validated (must be an absolute http/https URL) when enabled.
+  adServerUri?: string;
+  // Optional slate reference shown while the break is being resolved. Reuses
+  // the existing slate shape (uri/repetitions/duration); when omitted the
+  // channel/engine slate configuration is used.
+  slate?: SlateOpts;
+}
+
+// Shared slate reference shape, mirroring the loosely-typed `channel.slate`
+// object already consumed by the session plumbing (slateUri/slateRepetitions/
+// slateDuration).
+export interface SlateOpts {
+  uri: string;
+  repetitions?: number;
+  duration?: number;
+}
+
 export interface ChannelEngineOpts {
   defaultSlateUri?: string;
   slateRepetitions?: number;
   slateDuration?: number;
+  // Default ad-break configuration applied to channels that do not carry their
+  // own per-channel `adBreak`. Defaults to disabled when unset.
+  adBreak?: AdBreakOpts;
   redisUrl?: string;
   memcachedUrl?: string;
   sharedStoreCacheTTL?: number;
@@ -159,6 +188,10 @@ export interface Channel {
   audioTracks?: AudioTracks[];
   subtitleTracks?: SubtitleTracks[];
   closedCaptions?: ClosedCaptions[];
+  slate?: SlateOpts;
+  // Per-channel ad-break configuration. Overrides the engine-level `adBreak`
+  // default when present. Defaults to disabled when neither is set.
+  adBreak?: AdBreakOpts;
 }
 
 export interface ClosedCaptions {
@@ -218,6 +251,7 @@ export class ChannelEngine {
   private alwaysMapBandwidthByNearest: boolean;
   private defaultSlateUri?: string;
   private slateDuration?: number;
+  private adBreak?: AdBreakOpts;
   private assetMgr: IAssetManager;
   private streamSwitchManager?: any;
   private slateRepetitions?: number;
@@ -238,7 +272,45 @@ export class ChannelEngine {
   private sessionResetKey: string = "";
   private sessionEventStream: boolean = false;
   private sessionHealthKey: string = "";
-  
+
+  // Validate and normalize an ad-break configuration (issue #367).
+  // Returns a config that is always defined and disabled-by-default:
+  //   - undefined/omitted            -> { enabled: false }
+  //   - { enabled: false, ... }      -> { enabled: false } (endpoint ignored)
+  //   - { enabled: true, adServerUri } -> validated, with the slate reference
+  //                                       (if any) carried through
+  // Throws when an enabled break is missing a syntactically valid absolute
+  // http(s) ad-serving endpoint URL. `scope` is only used for error context.
+  private static normalizeAdBreak(adBreak: AdBreakOpts | undefined, scope: string): AdBreakOpts {
+    if (!adBreak || !adBreak.enabled) {
+      return { enabled: false };
+    }
+    if (!adBreak.adServerUri) {
+      throw new Error(`Ad-break configuration (${scope}) is enabled but no adServerUri was provided`);
+    }
+    let parsed: URL;
+    try {
+      parsed = new URL(adBreak.adServerUri);
+    } catch (err) {
+      throw new Error(`Ad-break configuration (${scope}) has an invalid adServerUri: ${adBreak.adServerUri}`);
+    }
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error(`Ad-break configuration (${scope}) adServerUri must be an http(s) URL: ${adBreak.adServerUri}`);
+    }
+    const normalized: AdBreakOpts = {
+      enabled: true,
+      adServerUri: adBreak.adServerUri
+    };
+    if (adBreak.slate && adBreak.slate.uri) {
+      normalized.slate = {
+        uri: adBreak.slate.uri,
+        repetitions: adBreak.slate.repetitions || 10,
+        duration: adBreak.slate.duration || 4000
+      };
+    }
+    return normalized;
+  }
+
   constructor(assetMgr: IAssetManager, options?: ChannelEngineOpts) {
     this.options = options;
     if (options && options.adCopyMgrUri) {
@@ -281,6 +353,10 @@ export class ChannelEngine {
       this.slateRepetitions = options.slateRepetitions || 10;
       this.slateDuration = options.slateDuration || 4000;
     }
+    // Ad-break config surface (issue #367). Validate and normalize the
+    // engine-level default; disabled when unset. Throws on an enabled break
+    // that lacks a valid ad-serving endpoint URL.
+    this.adBreak = ChannelEngine.normalizeAdBreak(options && options.adBreak, "engine");
     if (options && options.streamSwitchManager) {
       this.streamSwitchManager = options.streamSwitchManager;
     }
@@ -583,6 +659,7 @@ export class ChannelEngine {
         slateUri: channel.slate && channel.slate.uri ? channel.slate.uri : this.defaultSlateUri,
         slateRepetitions: channel.slate && channel.slate.repetitions ? channel.slate.repetitions : this.slateRepetitions,
         slateDuration: channel.slate && channel.slate.duration ? channel.slate.duration : this.slateDuration,
+        adBreak: channel.adBreak ? ChannelEngine.normalizeAdBreak(channel.adBreak, `channel ${channel.id}`) : this.adBreak,
         cloudWatchMetrics: this.logCloudWatchMetrics,
         sessionEventStream: options.sessionEventStream,
         rollingPDT: options.rollingPDT,

--- a/engine/session.js
+++ b/engine/session.js
@@ -97,6 +97,9 @@ class Session {
     // more VODs to play (see `_isEndOfScheduleSignal`). ENDLIST emission based on
     // this state is out of scope here and handled by #363.
     this.isEndOfSchedule = false;
+    // Ad-break / interstitial config surface (issue #367). Disabled by default;
+    // no interstitial tags are emitted from this yet (follow-up #368).
+    this.adBreak = { enabled: false };
     if (config) {
       if (config.alwaysNewSegments) {
         this.alwaysNewSegments = config.alwaysNewSegments;
@@ -165,6 +168,10 @@ class Session {
         this.slateRepetitions = config.slateRepetitions || 10;
         this.slateDuration = config.slateDuration || 4000;
         debug(`Will use slate URI ${this.slateUri} (${this.slateRepetitions} ${this.slateDuration}ms)`);
+      }
+      if (config.adBreak && config.adBreak.enabled) {
+        this.adBreak = config.adBreak;
+        debug(`Ad breaks enabled, ad server URI ${this.adBreak.adServerUri}`);
       }
       if (config.cloudWatchMetrics) {
         this.cloudWatchLogging = true;

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,7 @@
 export { ChannelEngine, 
   ChannelEngineOpts, 
+  AdBreakOpts,
+  SlateOpts,
   IAssetManager,
   IChannelManager,
   IStreamSwitchManager,

--- a/spec/engine/engine_spec.js
+++ b/spec/engine/engine_spec.js
@@ -56,6 +56,48 @@ describe("Channel Engine", () => {
     jasmine.clock().uninstall();
   });
 
+  describe("ad-break config validation (issue #367)", () => {
+    let testAssetManager;
+    let testChannelManager;
+
+    beforeEach(() => {
+      testAssetManager = new TestAssetManager();
+      testChannelManager = new TestChannelManager();
+    });
+
+    // NOTE: the module-level fastify instance is a singleton, so a *successful*
+    // ChannelEngine construction registers routes on it and cannot be repeated
+    // within a single process. These specs therefore only cover the validation
+    // paths that throw before any route registration happens (issue #367).
+
+    it("throws when an enabled ad-break config is missing the endpoint URL", () => {
+      expect(() => {
+        new ChannelEngine(testAssetManager, {
+          channelManager: testChannelManager,
+          adBreak: { enabled: true }
+        });
+      }).toThrowError(/adServerUri/);
+    });
+
+    it("throws when the ad-break endpoint URL is malformed", () => {
+      expect(() => {
+        new ChannelEngine(testAssetManager, {
+          channelManager: testChannelManager,
+          adBreak: { enabled: true, adServerUri: "not-a-url" }
+        });
+      }).toThrowError(/invalid adServerUri/);
+    });
+
+    it("throws when the ad-break endpoint URL is not http(s)", () => {
+      expect(() => {
+        new ChannelEngine(testAssetManager, {
+          channelManager: testChannelManager,
+          adBreak: { enabled: true, adServerUri: "ftp://ads.example.com/vast" }
+        });
+      }).toThrowError(/http\(s\)/);
+    });
+  });
+
   xit("is updated when new channels are added", async () => {
     const testAssetManager = new TestAssetManager();
     const testChannelManager = new TestChannelManager();

--- a/spec/engine/session_spec.js
+++ b/spec/engine/session_spec.js
@@ -18,6 +18,45 @@ describe("Session", () => {
     expect(id1).not.toEqual(id2);
   });
 
+  describe("ad-break config surface (issue #367)", () => {
+    it("defaults ad breaks to disabled when unconfigured", () => {
+      const sessionNoConfig = new Session("dummy", null, sessionLiveStore);
+      const sessionEmptyConfig = new Session("dummy", {}, sessionLiveStore);
+      expect(sessionNoConfig.adBreak).toEqual({ enabled: false });
+      expect(sessionEmptyConfig.adBreak).toEqual({ enabled: false });
+    });
+
+    it("stores an enabled ad-break config when provided", () => {
+      const session = new Session("dummy", {
+        adBreak: { enabled: true, adServerUri: "https://ads.example.com/vast" }
+      }, sessionLiveStore);
+      expect(session.adBreak.enabled).toEqual(true);
+      expect(session.adBreak.adServerUri).toEqual("https://ads.example.com/vast");
+    });
+
+    it("treats an explicitly disabled ad-break config as disabled", () => {
+      const session = new Session("dummy", {
+        adBreak: { enabled: false, adServerUri: "https://ads.example.com/vast" }
+      }, sessionLiveStore);
+      expect(session.adBreak).toEqual({ enabled: false });
+    });
+
+    it("carries a slate reference through when present on an enabled config", () => {
+      const session = new Session("dummy", {
+        adBreak: {
+          enabled: true,
+          adServerUri: "https://ads.example.com/vast",
+          slate: { uri: "https://slate.example.com/slate.mp4", repetitions: 5, duration: 3000 }
+        }
+      }, sessionLiveStore);
+      expect(session.adBreak.slate).toEqual({
+        uri: "https://slate.example.com/slate.mp4",
+        repetitions: 5,
+        duration: 3000
+      });
+    });
+  });
+
   it("sets the event flag when configured with { event: true }", () => {
     const session = new Session("dummy", { event: true }, sessionLiveStore);
     expect(session.event).toEqual(true);


### PR DESCRIPTION
## Summary
- Implements #367: config surface for SGAI HLS-interstitial ad breaks. First of the #367→#371 series. **No tag emission** — config + plumbing + validation + specs only.

## Changes
- `engine/server.ts`: add exported `AdBreakOpts` (`{ enabled, adServerUri?, slate? }`, disabled by default) and `SlateOpts`; add `adBreak?` to `ChannelEngineOpts` and per-`Channel` config; type the previously-untyped `channel.slate`. Exported from `index.ts`.
- Static `normalizeAdBreak()` validator: returns `{ enabled: false }` when off; when enabled, requires `adServerUri` and validates it parses as an absolute http(s) URL (throws otherwise); carries the slate reference with defaults (repetitions 10, duration 4000).
- Plumbed to `engine/session.js` mirroring the existing `slateUri`/`slateRepetitions`/`slateDuration` threading; per-channel `adBreak` overrides the engine default.
- Deprecated `adCopyMgrUri`/`adXchangeUri` left untouched.

## Test plan
- PROOF: `npm run build` → clean (no errors)
- PROOF: `npm test` → `90 specs, 0 failures, 7 pending specs` (baseline 83; +7 specs: session default/parse/disabled/slate carry-through, engine validation for missing/malformed/non-http endpoint)

Closes #367

🤖 Automated via Channel Engine Dev daily-backlog-pr skill