### PR TITLE
feat: emit HLS interstitial EXT-X-DATERANGE tags for configured ad breaks

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -1327,6 +1327,7 @@ class Session {
                   newVod.addMetadata(k, vodResponse.timedMetadata[k]);
                 })
               }
+              this._addInterstitialMetadata(newVod, vodResponse.unixTs);
               currentVod = newVod;
               if (vodResponse.desiredDuration) {
                 try {
@@ -1516,6 +1517,7 @@ class Session {
                   newVod.addMetadata(k, vodResponse.timedMetadata[k]);
                 })
               }
+              this._addInterstitialMetadata(newVod, vodResponse.unixTs);
               this.produceEvent({
                 type: 'NEXT_VOD_SELECTED',
                 data: {
@@ -1829,6 +1831,45 @@ class Session {
     }
     const separator = m3u8.endsWith("\n") ? "" : "\n";
     return m3u8 + separator + "#EXT-X-ENDLIST\n";
+  }
+
+  // Attach the HLS-interstitial EXT-X-DATERANGE metadata for a configured ad
+  // break to a freshly-created content VOD (issue #368). Reuses the existing
+  // per-VOD `addMetadata`/`rangeMetadata` daterange pathway (the same one the
+  // slate VODs use for id/start-date/planned-duration), so the tag is rendered
+  // by @eyevinn/hls-vodtolive at the VOD's start segment. The `class` and
+  // `x-asset-uri`/`x-asset-list` keys are uppercased and rendered as standard
+  // DATERANGE attributes by the vod lib's daterange formatter.
+  //
+  // Strictly gated on `this.adBreak.enabled`: when ad breaks are disabled (the
+  // default) this is a no-op and the served manifest is byte-identical to the
+  // pre-#368 output. The asset reference is sourced from the #367 config
+  // (slate.uri preferred, falling back to adServerUri); resolving the real ad
+  // asset from the ad endpoint is out of scope here (#370).
+  _addInterstitialMetadata(vod, timestamp) {
+    if (!vod || !this.adBreak || !this.adBreak.enabled) {
+      return;
+    }
+    const assetUri =
+      (this.adBreak.slate && this.adBreak.slate.uri) || this.adBreak.adServerUri;
+    if (!assetUri) {
+      return;
+    }
+    const startDate = new Date(
+      typeof timestamp === "number" ? timestamp : Date.now()
+    ).toISOString();
+    let plannedDuration = 0;
+    if (this.adBreak.slate && this.adBreak.slate.duration) {
+      const reps = this.adBreak.slate.repetitions || 1;
+      plannedDuration = (reps * this.adBreak.slate.duration) / 1000;
+    }
+    vod.addMetadata("class", "com.apple.hls.interstitial");
+    vod.addMetadata("id", `adbreak-${this._sessionId}-${startDate}`);
+    vod.addMetadata("start-date", startDate);
+    if (plannedDuration > 0) {
+      vod.addMetadata("planned-duration", plannedDuration);
+    }
+    vod.addMetadata("x-asset-uri", assetUri);
   }
 
   _isEndOfScheduleSignal(nextVod) {

--- a/spec/engine/session_spec.js
+++ b/spec/engine/session_spec.js
@@ -1,4 +1,6 @@
 const Session = require("../../engine/session.js");
+const HLSVod = require("@eyevinn/hls-vodtolive");
+const fs = require("fs");
 
 const { SessionStateStore } = require("../../engine/session_state.js");
 const { PlayheadStateStore } = require("../../engine/playhead_state.js");
@@ -54,6 +56,97 @@ describe("Session", () => {
         repetitions: 5,
         duration: 3000
       });
+    });
+  });
+
+  describe("HLS-interstitial EXT-X-DATERANGE emission (issue #368)", () => {
+    // Loads a real content VOD from the vod-lib test vectors, applies the
+    // session's interstitial metadata via the same addMetadata pathway the
+    // engine uses at VOD creation, and renders the live media playlist so we
+    // can assert the produced EXT-X-DATERANGE tag byte-for-byte.
+    const VODLIB_TV = "node_modules/@eyevinn/hls-vodtolive/testvectors/hls1/";
+    const masterLoader = () => fs.createReadStream(VODLIB_TV + "master.m3u8");
+    const mediaLoader = (bandwidth) =>
+      fs.createReadStream(VODLIB_TV + bandwidth + ".m3u8");
+    const FIXED_TS = Date.UTC(2026, 8, 4, 0, 0, 0); // 2026-09-04T00:00:00.000Z
+
+    async function renderFirstMediaSequence(session) {
+      const vod = new HLSVod("http://mock.com/master.m3u8", [], FIXED_TS, 0);
+      session._addInterstitialMetadata(vod, FIXED_TS);
+      await vod.load(masterLoader, mediaLoader);
+      const bw = vod.getBandwidths()[0];
+      return vod.getLiveMediaSequences(0, bw, 0, 0);
+    }
+
+    it("emits an interstitial DATERANGE at the break start when ad breaks are enabled", async () => {
+      const session = new Session("dummy", {
+        adBreak: {
+          enabled: true,
+          adServerUri: "https://ads.example.com/vast",
+          slate: { uri: "https://slate.example.com/slate.mp4", repetitions: 2, duration: 4000 }
+        }
+      }, sessionLiveStore);
+
+      const m3u8 = await renderFirstMediaSequence(session);
+      const daterange = m3u8.split("\n").find((l) => l.startsWith("#EXT-X-DATERANGE"));
+
+      expect(daterange).toBeDefined();
+      // Standard Apple HLS-interstitial class identifier.
+      expect(daterange).toContain('CLASS="com.apple.hls.interstitial"');
+      expect(daterange).toContain('START-DATE="2026-09-04T00:00:00.000Z"');
+      // Slate reference is preferred as the asset source (2 x 4000ms = 8.000s).
+      expect(daterange).toContain('X-ASSET-URI="https://slate.example.com/slate.mp4"');
+      expect(daterange).toContain("PLANNED-DURATION=8.000");
+      expect(daterange).toMatch(/ID="adbreak-/);
+    });
+
+    it("falls back to the ad server URI as the interstitial asset when no slate is configured", async () => {
+      const session = new Session("dummy", {
+        adBreak: { enabled: true, adServerUri: "https://ads.example.com/vast" }
+      }, sessionLiveStore);
+
+      const m3u8 = await renderFirstMediaSequence(session);
+      const daterange = m3u8.split("\n").find((l) => l.startsWith("#EXT-X-DATERANGE"));
+
+      expect(daterange).toBeDefined();
+      expect(daterange).toContain('X-ASSET-URI="https://ads.example.com/vast"');
+      // No slate duration configured -> no PLANNED-DURATION attribute emitted.
+      expect(daterange).not.toContain("PLANNED-DURATION");
+    });
+
+    it("emits no DATERANGE and a byte-identical playlist when ad breaks are disabled", async () => {
+      const enabledSession = new Session("dummy", {
+        adBreak: { enabled: true, adServerUri: "https://ads.example.com/vast" }
+      }, sessionLiveStore);
+      const disabledSession = new Session("dummy", null, sessionLiveStore);
+
+      // Baseline playlist with the feature disabled (default config).
+      const disabledM3u8 = await renderFirstMediaSequence(disabledSession);
+      // Same VOD/content with the feature enabled produces the interstitial tag.
+      const enabledM3u8 = await renderFirstMediaSequence(enabledSession);
+
+      expect(/#EXT-X-DATERANGE/.test(disabledM3u8)).toEqual(false);
+      expect(/#EXT-X-DATERANGE/.test(enabledM3u8)).toEqual(true);
+
+      // Proof that disabled output is unchanged: stripping the injected
+      // interstitial lines from the enabled playlist yields the disabled one.
+      const enabledStripped = enabledM3u8
+        .split("\n")
+        .filter((l) => !l.startsWith("#EXT-X-DATERANGE") && !l.startsWith("#EXT-X-PROGRAM-DATE-TIME"))
+        .join("\n");
+      const disabledStripped = disabledM3u8
+        .split("\n")
+        .filter((l) => !l.startsWith("#EXT-X-PROGRAM-DATE-TIME"))
+        .join("\n");
+      expect(enabledStripped).toEqual(disabledStripped);
+    });
+
+    it("is a no-op for _addInterstitialMetadata when ad breaks are disabled", () => {
+      const session = new Session("dummy", null, sessionLiveStore);
+      const calls = [];
+      const fakeVod = { addMetadata: (k, v) => calls.push([k, v]) };
+      session._addInterstitialMetadata(fakeVod, FIXED_TS);
+      expect(calls.length).toEqual(0);
     });
   });
 


### PR DESCRIPTION
## Summary
- Implements #368: emit HLS-interstitial `EXT-X-DATERANGE` tags for a configured ad break (builds on the #367 config surface). Asset resolution via the ad-serving endpoint is #370; slate/duration alignment is #369.

## Changes
- `engine/session.js`: add `_addInterstitialMetadata(vod, timestamp)`, invoked at the two content-VOD creation sites (after the existing `timedMetadata` loop). Reuses the existing per-VOD `addMetadata`/`rangeMetadata` daterange pathway — the same mechanism slate VODs already use — so no `@eyevinn/hls-vodtolive` change is needed (verified the vodlib renders arbitrary daterange keys).
- Emits `#EXT-X-DATERANGE:CLASS="com.apple.hls.interstitial",ID=...,START-DATE=...,PLANNED-DURATION=...,X-ASSET-URI=...`. `CLASS` is the Apple HLS-interstitial spec identifier. Asset source: configured `slate.uri`, falling back to `adServerUri`. `PLANNED-DURATION` derived from slate repetitions×duration (omitted when no slate duration).
- **Strictly gated on `adBreak.enabled`**: when disabled (the default) the helper is a no-op and manifests are byte-identical to before.

## Test plan
- PROOF: `npm run build` → clean (no errors)
- PROOF: `npm test` → `94 specs, 0 failures, 7 pending specs` (baseline 90; +4 specs: enabled w/ slate attributes, enabled fallback to adServerUri, disabled-vs-enabled byte-identical after stripping injected lines, no-op when disabled)

Closes #368

🤖 Automated via Channel Engine Dev daily-backlog-pr skill