### PR TITLE
feat: resolve interstitial ad asset from configured ad-serving endpoint

### DIFF
--- a/engine/session.js
+++ b/engine/session.js
@@ -1,5 +1,6 @@
 const crypto = require('crypto');
 const debug = require('debug')('engine-session');
+const fetch = require('node-fetch');
 const HLSVod = require('@eyevinn/hls-vodtolive');
 const m3u8 = require('@eyevinn/m3u8');
 const HLSRepeatVod = require('@eyevinn/hls-repeat');
@@ -26,6 +27,10 @@ const END_OF_SCHEDULE = "END_OF_SCHEDULE";
 const DEFAULT_PLAYHEAD_DIFF_THRESHOLD = 1000;
 const DEFAULT_MAX_TICK_INTERVAL = 10000;
 const DEFAULT_DIFF_COMPENSATION_RATE = 0.5;
+// Max time (ms) to wait for the configured ad-serving endpoint (#370) before
+// giving up and falling back to the slate-only break. Kept short so a slow or
+// unreachable endpoint never stalls a session tick.
+const AD_SERVER_TIMEOUT_MS = 2000;
 
 const timer = ms => new Promise(res => setTimeout(res, ms));
 
@@ -1327,7 +1332,8 @@ class Session {
                   newVod.addMetadata(k, vodResponse.timedMetadata[k]);
                 })
               }
-              this._addInterstitialMetadata(newVod, vodResponse.unixTs);
+              const firstVodAdAsset = await this._resolveAdBreakAsset();
+              this._addInterstitialMetadata(newVod, vodResponse.unixTs, firstVodAdAsset);
               currentVod = newVod;
               if (vodResponse.desiredDuration) {
                 try {
@@ -1517,7 +1523,8 @@ class Session {
                   newVod.addMetadata(k, vodResponse.timedMetadata[k]);
                 })
               }
-              this._addInterstitialMetadata(newVod, vodResponse.unixTs);
+              const nextVodAdAsset = await this._resolveAdBreakAsset();
+              this._addInterstitialMetadata(newVod, vodResponse.unixTs, nextVodAdAsset);
               this.produceEvent({
                 type: 'NEXT_VOD_SELECTED',
                 data: {
@@ -1843,16 +1850,24 @@ class Session {
   //
   // Strictly gated on `this.adBreak.enabled`: when ad breaks are disabled (the
   // default) this is a no-op and the served manifest is byte-identical to the
-  // pre-#368 output. The asset reference is sourced from the #367 config
-  // (slate.uri preferred, falling back to adServerUri); resolving the real ad
-  // asset from the ad endpoint is out of scope here (#370).
-  _addInterstitialMetadata(vod, timestamp) {
+  // pre-#368 output.
+  //
+  // Asset-source precedence (#370): when the caller has resolved a real ad
+  // asset from the configured ad-serving endpoint (`_resolveAdBreakAsset()`),
+  // it is passed in as `resolvedAsset` and its `assetUri`/`assetList` becomes
+  // the interstitial `X-ASSET-URI`/`X-ASSET-LIST`. When no endpoint asset was
+  // resolved (endpoint unconfigured, or a timeout/HTTP-error/malformed response
+  // that made the resolver fall back), we degrade to the #367 config reference
+  // (slate.uri preferred, then adServerUri) so the break still renders.
+  _addInterstitialMetadata(vod, timestamp, resolvedAsset) {
     if (!vod || !this.adBreak || !this.adBreak.enabled) {
       return;
     }
-    const assetUri =
+    const fallbackUri =
       (this.adBreak.slate && this.adBreak.slate.uri) || this.adBreak.adServerUri;
-    if (!assetUri) {
+    const assetList = resolvedAsset && resolvedAsset.assetList;
+    const assetUri = (resolvedAsset && resolvedAsset.assetUri) || fallbackUri;
+    if (!assetList && !assetUri) {
       return;
     }
     const startDate = new Date(
@@ -1869,7 +1884,76 @@ class Session {
     if (plannedDuration > 0) {
       vod.addMetadata("planned-duration", plannedDuration);
     }
-    vod.addMetadata("x-asset-uri", assetUri);
+    // A resolved asset-list (multiple ads) takes precedence over a single URI
+    // and maps to X-ASSET-LIST; otherwise a single X-ASSET-URI is emitted.
+    if (assetList) {
+      vod.addMetadata("x-asset-list", assetList);
+    } else {
+      vod.addMetadata("x-asset-uri", assetUri);
+    }
+  }
+
+  // Ad-serving endpoint client (issue #370).
+  //
+  // When an ad break is enabled and an `adBreak.adServerUri` is configured,
+  // query that endpoint and map its JSON response to the interstitial asset
+  // reference consumed by `_addInterstitialMetadata`.
+  //
+  // Response contract (kept deliberately generic — no ad-product specifics):
+  //   { "assetUri": "<uri>" }                     -> single X-ASSET-URI
+  //   { "assetList": "<uri>" }                    -> an X-ASSET-LIST endpoint
+  //   { "assets": ["<uri>", ...] }                -> first entry -> X-ASSET-URI
+  // Returns `{ assetUri }` or `{ assetList }` on success, or `null` when there
+  // is nothing to resolve or on ANY failure.
+  //
+  // Log-and-continue (per CLAUDE.md): a timeout, non-2xx HTTP status, network
+  // error, or malformed/empty JSON body all resolve to `null` (never throw), so
+  // the caller falls back to the slate-only break and the session tick is never
+  // interrupted. Returns `null` immediately (no fetch) when the feature is
+  // disabled or no `adServerUri` is configured.
+  async _resolveAdBreakAsset(fetchImpl) {
+    if (!this.adBreak || !this.adBreak.enabled || !this.adBreak.adServerUri) {
+      return null;
+    }
+    const doFetch = fetchImpl || fetch;
+    const uri = this.adBreak.adServerUri;
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), AD_SERVER_TIMEOUT_MS);
+    try {
+      const response = await doFetch(uri, {
+        signal: controller.signal,
+        headers: { accept: "application/json" }
+      });
+      if (!response || !response.ok) {
+        debug(
+          `[${this._sessionId}]: ad-server endpoint ${uri} returned ` +
+          `${response ? response.status : "no response"}, falling back to slate`
+        );
+        return null;
+      }
+      const body = await response.json();
+      if (!body || typeof body !== "object") {
+        debug(`[${this._sessionId}]: ad-server endpoint ${uri} returned a non-object body, falling back to slate`);
+        return null;
+      }
+      if (typeof body.assetList === "string" && body.assetList) {
+        return { assetList: body.assetList };
+      }
+      if (typeof body.assetUri === "string" && body.assetUri) {
+        return { assetUri: body.assetUri };
+      }
+      if (Array.isArray(body.assets) && typeof body.assets[0] === "string" && body.assets[0]) {
+        return { assetUri: body.assets[0] };
+      }
+      debug(`[${this._sessionId}]: ad-server endpoint ${uri} response had no usable asset, falling back to slate`);
+      return null;
+    } catch (err) {
+      // Covers AbortError (timeout), network errors, and JSON parse errors.
+      debug(`[${this._sessionId}]: ad-server endpoint ${uri} request failed (${err && err.message ? err.message : err}), falling back to slate`);
+      return null;
+    } finally {
+      clearTimeout(timeout);
+    }
   }
 
   // Ad-break slate coordination (issue #369).
@@ -1903,9 +1987,13 @@ class Session {
     const timestamp = typeof unixTs === "number" ? unixTs : Date.now();
     // `injectSlateLoaders` lets callers (tests) feed the repeated slate asset
     // from fixtures instead of the network; production passes nothing so the
-    // slate is fetched from `slate.uri` as usual.
-    const { master, media } = injectSlateLoaders || {};
-    return new Promise((resolve, reject) => {
+    // slate is fetched from `slate.uri` as usual. It may also carry a `fetch`
+    // stub used to resolve the ad-break asset (#370) without real network.
+    const { master, media, fetch: fetchImpl } = injectSlateLoaders || {};
+    // Resolve the real ad asset from the configured endpoint before rendering
+    // the slate so the interstitial DATERANGE can reference it; on any failure
+    // this yields null and the tag degrades to the slate reference.
+    return this._resolveAdBreakAsset(fetchImpl).then((resolvedAsset) => new Promise((resolve, reject) => {
       try {
         const slateVod = new HLSRepeatVod(slate.uri, reps);
         let hlsVod;
@@ -1926,8 +2014,9 @@ class Session {
             hlsVod = new HLSVod(slate.uri, null, timestamp, null, m3u8Header(this._instanceId), hlsOpts);
             // Bracket exactly the slate: the interstitial DATERANGE lands on the
             // slate's first segment (START-DATE = break boundary) and its
-            // PLANNED-DURATION equals the slate run length.
-            this._addInterstitialMetadata(hlsVod, timestamp);
+            // PLANNED-DURATION equals the slate run length. The asset reference
+            // is the endpoint-resolved ad (or the slate fallback) from #370.
+            this._addInterstitialMetadata(hlsVod, timestamp, resolvedAsset);
             const slateMediaManifestLoader = (bw) => {
               let mediaManifestStream = new Readable();
               // `HLSRepeatVod` prepends an EXT-X-DISCONTINUITY before the first
@@ -1980,7 +2069,7 @@ class Session {
       } catch (err) {
         reject(err);
       }
-    });
+    }));
   }
 
   _isEndOfScheduleSignal(nextVod) {

--- a/spec/engine/session_spec.js
+++ b/spec/engine/session_spec.js
@@ -291,6 +291,199 @@ describe("Session", () => {
     });
   });
 
+  describe("ad-serving endpoint asset resolution (issue #370)", () => {
+    const SLATE_TV = "spec/testvectors/slate/";
+    const slateMaster = () => fs.createReadStream(SLATE_TV + "master.m3u8");
+    const slateMedia = () => fs.createReadStream(SLATE_TV + "media.m3u8");
+    const FIXED_TS = Date.UTC(2026, 8, 4, 0, 0, 0);
+    const AD_ENDPOINT = "https://ads.example.com/decision";
+
+    // Builds a stub matching the subset of the node-fetch Response API the
+    // resolver uses (ok/status/json). No real network is ever contacted.
+    function fetchStub(behaviour) {
+      const calls = [];
+      const stub = async (uri, opts) => {
+        calls.push({ uri, opts });
+        return behaviour(uri, opts);
+      };
+      stub.calls = calls;
+      return stub;
+    }
+    const okResponse = (body) => ({ ok: true, status: 200, json: async () => body });
+    const errResponse = (status) => ({ ok: false, status, json: async () => ({}) });
+
+    function endpointSession(extra) {
+      return new Session("dummy", {
+        adBreak: Object.assign(
+          { enabled: true, adServerUri: AD_ENDPOINT },
+          extra
+        )
+      }, sessionLiveStore);
+    }
+
+    it("resolves a single asset URI from the endpoint response ({ assetUri })", async () => {
+      const session = endpointSession();
+      const stub = fetchStub(() => okResponse({ assetUri: "https://cdn.example.com/ad-a.m3u8" }));
+      const resolved = await session._resolveAdBreakAsset(stub);
+      expect(resolved).toEqual({ assetUri: "https://cdn.example.com/ad-a.m3u8" });
+      // The configured endpoint was queried exactly once.
+      expect(stub.calls.length).toEqual(1);
+      expect(stub.calls[0].uri).toEqual(AD_ENDPOINT);
+    });
+
+    it("resolves an asset-list URI from the endpoint response ({ assetList })", async () => {
+      const session = endpointSession();
+      const stub = fetchStub(() => okResponse({ assetList: "https://cdn.example.com/ads.json" }));
+      const resolved = await session._resolveAdBreakAsset(stub);
+      expect(resolved).toEqual({ assetList: "https://cdn.example.com/ads.json" });
+    });
+
+    it("resolves the first entry of an { assets: [...] } response as the asset URI", async () => {
+      const session = endpointSession();
+      const stub = fetchStub(() => okResponse({ assets: ["https://cdn.example.com/first.m3u8", "https://cdn.example.com/second.m3u8"] }));
+      const resolved = await session._resolveAdBreakAsset(stub);
+      expect(resolved).toEqual({ assetUri: "https://cdn.example.com/first.m3u8" });
+    });
+
+    it("does not fetch and returns null when ad breaks are disabled", async () => {
+      const session = new Session("dummy", null, sessionLiveStore);
+      const stub = fetchStub(() => okResponse({ assetUri: "https://cdn.example.com/ad.m3u8" }));
+      const resolved = await session._resolveAdBreakAsset(stub);
+      expect(resolved).toBeNull();
+      expect(stub.calls.length).toEqual(0);
+    });
+
+    it("does not fetch and returns null when enabled but no adServerUri is configured", async () => {
+      const session = new Session("dummy", {
+        adBreak: { enabled: true, slate: { uri: "https://slate.example.com/master.m3u8", repetitions: 2, duration: 4000 } }
+      }, sessionLiveStore);
+      const stub = fetchStub(() => okResponse({ assetUri: "x" }));
+      const resolved = await session._resolveAdBreakAsset(stub);
+      expect(resolved).toBeNull();
+      expect(stub.calls.length).toEqual(0);
+    });
+
+    it("falls back to null (slate) on an endpoint timeout without throwing", async () => {
+      const session = endpointSession();
+      // Emulate node-fetch aborting on the timeout: reject with an AbortError.
+      const stub = fetchStub(() => {
+        const err = new Error("The operation was aborted");
+        err.name = "AbortError";
+        return Promise.reject(err);
+      });
+      const resolved = await session._resolveAdBreakAsset(stub);
+      expect(resolved).toBeNull();
+    });
+
+    it("falls back to null (slate) on a non-2xx HTTP status", async () => {
+      const session = endpointSession();
+      const stub = fetchStub(() => errResponse(503));
+      const resolved = await session._resolveAdBreakAsset(stub);
+      expect(resolved).toBeNull();
+    });
+
+    it("falls back to null (slate) on a malformed JSON body", async () => {
+      const session = endpointSession();
+      const stub = fetchStub(() => ({ ok: true, status: 200, json: async () => { throw new SyntaxError("Unexpected token < in JSON"); } }));
+      const resolved = await session._resolveAdBreakAsset(stub);
+      expect(resolved).toBeNull();
+    });
+
+    it("falls back to null (slate) when the response has no usable asset field", async () => {
+      const session = endpointSession();
+      const stub = fetchStub(() => okResponse({ foo: "bar" }));
+      const resolved = await session._resolveAdBreakAsset(stub);
+      expect(resolved).toBeNull();
+    });
+
+    it("feeds a resolved endpoint asset into the interstitial X-ASSET-URI over the slate", async () => {
+      const session = new Session("dummy", {
+        adBreak: {
+          enabled: true,
+          adServerUri: AD_ENDPOINT,
+          slate: { uri: "https://slate.example.com/master.m3u8", repetitions: 2, duration: 4000 }
+        }
+      }, sessionLiveStore);
+      const stub = fetchStub(() => okResponse({ assetUri: "https://cdn.example.com/resolved-ad.m3u8" }));
+
+      const slateVod = await session._buildAdBreakSlate(null, FIXED_TS, {
+        master: slateMaster,
+        media: slateMedia,
+        fetch: stub
+      });
+      const bw = slateVod.getBandwidths()[0];
+      const m3u8 = slateVod.getLiveMediaSequences(0, bw, 0, 0);
+      const daterange = m3u8.split("\n").find((l) => l.startsWith("#EXT-X-DATERANGE"));
+
+      expect(daterange).toBeDefined();
+      // The endpoint-resolved asset wins over the configured slate.uri.
+      expect(daterange).toContain('X-ASSET-URI="https://cdn.example.com/resolved-ad.m3u8"');
+      expect(daterange).not.toContain('X-ASSET-URI="https://slate.example.com/master.m3u8"');
+      // Slate still fills the break window (PLANNED-DURATION spans the slate run).
+      expect(daterange).toContain("PLANNED-DURATION=8.000");
+    });
+
+    it("maps a resolved asset-list to X-ASSET-LIST on the interstitial tag", async () => {
+      const session = new Session("dummy", {
+        adBreak: {
+          enabled: true,
+          adServerUri: AD_ENDPOINT,
+          slate: { uri: "https://slate.example.com/master.m3u8", repetitions: 2, duration: 4000 }
+        }
+      }, sessionLiveStore);
+      const stub = fetchStub(() => okResponse({ assetList: "https://cdn.example.com/ads.json" }));
+
+      const slateVod = await session._buildAdBreakSlate(null, FIXED_TS, {
+        master: slateMaster,
+        media: slateMedia,
+        fetch: stub
+      });
+      const bw = slateVod.getBandwidths()[0];
+      const m3u8 = slateVod.getLiveMediaSequences(0, bw, 0, 0);
+      const daterange = m3u8.split("\n").find((l) => l.startsWith("#EXT-X-DATERANGE"));
+
+      expect(daterange).toBeDefined();
+      expect(daterange).toContain('X-ASSET-LIST="https://cdn.example.com/ads.json"');
+      expect(daterange).not.toContain("X-ASSET-URI");
+    });
+
+    it("falls back to the slate asset in the interstitial tag when the endpoint fails", async () => {
+      const session = new Session("dummy", {
+        adBreak: {
+          enabled: true,
+          adServerUri: AD_ENDPOINT,
+          slate: { uri: "https://slate.example.com/master.m3u8", repetitions: 2, duration: 4000 }
+        }
+      }, sessionLiveStore);
+      const stub = fetchStub(() => errResponse(500));
+
+      const slateVod = await session._buildAdBreakSlate(null, FIXED_TS, {
+        master: slateMaster,
+        media: slateMedia,
+        fetch: stub
+      });
+      const bw = slateVod.getBandwidths()[0];
+      const m3u8 = slateVod.getLiveMediaSequences(0, bw, 0, 0);
+      const daterange = m3u8.split("\n").find((l) => l.startsWith("#EXT-X-DATERANGE"));
+
+      expect(daterange).toBeDefined();
+      // Endpoint failure => slate reference is used, break still renders.
+      expect(daterange).toContain('X-ASSET-URI="https://slate.example.com/master.m3u8"');
+      expect(daterange).toContain("PLANNED-DURATION=8.000");
+    });
+
+    it("_addInterstitialMetadata prefers a resolved asset over the slate/adServer fallback", () => {
+      const session = endpointSession({
+        slate: { uri: "https://slate.example.com/master.m3u8", repetitions: 2, duration: 4000 }
+      });
+      const calls = [];
+      const fakeVod = { addMetadata: (k, v) => calls.push([k, v]) };
+      session._addInterstitialMetadata(fakeVod, FIXED_TS, { assetUri: "https://cdn.example.com/resolved.m3u8" });
+      const assetUri = calls.find((c) => c[0] === "x-asset-uri");
+      expect(assetUri[1]).toEqual("https://cdn.example.com/resolved.m3u8");
+    });
+  });
+
   it("sets the event flag when configured with { event: true }", () => {
     const session = new Session("dummy", { event: true }, sessionLiveStore);
     expect(session.event).toEqual(true);


### PR DESCRIPTION
## Summary
- Implements #370: source the interstitial `X-ASSET-URI`/`X-ASSET-LIST` from the configured `adBreak.adServerUri` endpoint, with slate fallback on any failure. Builds on #367/#368/#369.

## Changes
- `engine/session.js`: add `async _resolveAdBreakAsset(fetchImpl?)` → `{ assetUri } | { assetList } | null`. Reuses the existing `node-fetch` (^2) dependency with an `AbortController` 2s timeout (matching `session_live.js`'s pattern). Response contract (documented in-code, generic): `{ assetUri }` → `X-ASSET-URI`; `{ assetList }` → `X-ASSET-LIST`; `{ assets: [...] }` → first entry → `X-ASSET-URI`.
- `_addInterstitialMetadata(vod, timestamp, resolvedAsset?)` gains a resolved-asset param: emits the endpoint-resolved asset when present, else degrades to the prior `slate.uri || adServerUri`. Wired at the two content-VOD sites and in `_buildAdBreakSlate` (all `await` the resolver).
- Failure handling (log-and-continue per CLAUDE.md): timeout (`AbortError`), HTTP error (`!response.ok`), and malformed JSON are all caught → return `null` → slate fallback; the session never throws out of the tick.
- **Disabled = no fetch**: resolver returns `null` immediately when `!adBreak.enabled` or no `adServerUri`.

## Test plan
- PROOF: `npm run build` → clean (no errors)
- PROOF: `npm test` → `113 specs, 0 failures, 7 pending specs` (baseline 100; +13 specs, all using a stubbed fetch — no real network: success mappings, disabled/no-endpoint no-fetch, timeout/HTTP-error/malformed → slate fallback, and integration through `_buildAdBreakSlate`)

Closes #370

🤖 Automated via Channel Engine Dev daily-backlog-pr skill