### PR TITLE
chore: document HLS-interstitial ad-break configuration and behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,18 @@ Please see the [Documentation](https://vod2live.docs.eyevinn.technology) for int
 - Improved performance with Redis connection pooling and pipelining
 - Enhanced stability in High Availability mode
 - Support for livemix with demuxed content (TS and CMAF)
+- Support for SGAI HLS-interstitial ad breaks with client-side ad replacement
 - And much more!
+
+### Ad breaks (HLS interstitials)
+
+A channel can be configured to open SGAI HLS-interstitial ad breaks. When
+enabled, the engine emits EXT-X-DATERANGE interstitial metadata on the
+manifest and resolves the ad asset from a configured ad-serving endpoint, with
+a slate fallback if that endpoint cannot be reached. Configure it through the
+`adBreak` option (engine-level default or per channel); see
+[docs/reference.md](docs/reference.md#ad-break-configuration-hls-interstitials)
+for the full field reference and `examples/adbreak.ts` for a runnable example.
 
 ## System Requirements
 
@@ -198,6 +209,7 @@ In addition there other reference implemetations that can be used:
 - `examples/drm.ts` : example with DRM
 - `examples/autocreate.ts` : example to auto create channel on demand
 - `examples/truncate.ts` : example when trimming start and end of a VOD
+- `examples/adbreak.ts` : example with a channel configured for HLS-interstitial ad breaks
 
 ### Source linking hls-vodtolive library
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -28,3 +28,55 @@ uri | HLSURI | string | URI to HLS master manifest for the VOD
 title (optional) | TITLE | string |  The title of the asset
 playlistPosition (optional) | POSITION | id | Current position of the VOD in the playlist
 
+## Ad-break configuration (HLS interstitials)
+
+The engine can annotate a channel's manifest with SGAI HLS-interstitial
+[EXT-X-DATERANGE](https://datatracker.ietf.org/doc/html/rfc8216) tags
+(`CLASS="com.apple.hls.interstitial"`) so that an HLS player performs
+client-side ad replacement at the VOD boundary. Ad breaks are configured
+through the `adBreak` object, which can be set either as an engine-level
+default (on `ChannelEngineOpts`) or per channel (on a `Channel`). A
+per-channel `adBreak` overrides the engine-level default. Ad breaks default
+to **disabled** when neither is set.
+
+### `adBreak` fields
+
+Field | Type | Default | Description
+----- | ---- | ------- | -----------
+enabled | boolean | `false` | Master enable flag. When `false`, no interstitial metadata is emitted and the served manifest is byte-identical to the non-ad-break output.
+adServerUri | string | (none) | URL of the ad-serving endpoint queried to fill a break. **Required** when `enabled` is `true`, and validated to be an absolute `http`/`https` URL — an enabled break with a missing or invalid `adServerUri` throws at engine construction.
+slate (optional) | object | (none) | Slate reference shown while the break is being resolved and used as the fallback asset if the ad-serving endpoint cannot be resolved. Omit to fall back to the channel/engine slate configuration.
+
+### `adBreak.slate` fields
+
+Field | Type | Default | Description
+----- | ---- | ------- | -----------
+uri | string | (none) | URI to the slate HLS VOD.
+repetitions (optional) | number | `10` | Number of times the slate VOD is repeated to fill the break window.
+duration (optional) | number | `4000` | Duration of a single slate repetition, in milliseconds. Together with `repetitions` this drives the interstitial `PLANNED-DURATION`.
+
+### Ad replacement flow
+
+When a break is opened on an enabled channel:
+
+1. The engine queries the configured `adServerUri` for an ad asset (with an
+   `Accept: application/json` request and a 2-second timeout).
+2. The endpoint answers with a JSON body in one of these shapes:
+
+   Response body | Interstitial attribute
+   ------------- | ----------------------
+   `{ "assetUri": "<uri>" }` | `X-ASSET-URI` (single asset)
+   `{ "assetList": "<uri>" }` | `X-ASSET-LIST` (an asset-list endpoint)
+   `{ "assets": ["<uri>", ...] }` | `X-ASSET-URI` from the first entry
+
+3. The resolved asset is written into an EXT-X-DATERANGE HLS interstitial on
+   the served manifest, and the HLS player fetches and plays the ad in place
+   of (client-side ad replacement), leaving the underlying VOD2Live stream
+   untouched.
+4. If the endpoint times out, returns a non-2xx status, or returns a
+   malformed/empty body, the engine logs and falls back to the configured
+   slate (or the channel/engine slate) so the break still renders — the
+   session tick is never interrupted.
+
+See `examples/adbreak.ts` for a runnable channel wired with an ad break.
+

--- a/examples/adbreak.ts
+++ b/examples/adbreak.ts
@@ -1,0 +1,115 @@
+/*
+ * Reference implementation showing a channel configured for
+ * HLS-interstitial (SGAI) ad breaks.
+ *
+ * When `adBreak.enabled` is true and an `adServerUri` is configured, the
+ * engine annotates the served manifest with an EXT-X-DATERANGE HLS
+ * interstitial (class `com.apple.hls.interstitial`) at the VOD boundary and
+ * resolves the ad asset from the ad-serving endpoint. If the endpoint cannot
+ * be reached in time (2s), the break falls back to the configured slate.
+ * See `docs/reference.md` for the full field reference.
+ */
+
+import { ChannelEngine, ChannelEngineOpts,
+  IAssetManager, IChannelManager,
+  VodRequest, VodResponse, Channel, ChannelProfile
+} from "../index";
+
+class RefAssetManager implements IAssetManager {
+  private assets;
+  private pos;
+  constructor(opts?) {
+    this.assets = {
+      "1": [
+        {
+          id: 1,
+          title: "Tears of Steel",
+          uri: "https://maitv-vod.lab.eyevinn.technology/tearsofsteel_4k.mov/master.m3u8",
+        },
+        {
+          id: 2,
+          title: "VINN",
+          uri: "https://maitv-vod.lab.eyevinn.technology/VINN.mp4/master.m3u8",
+        },
+      ],
+    };
+    this.pos = { "1": 0 };
+  }
+
+  getNextVod(vodRequest: VodRequest): Promise<VodResponse> {
+    return new Promise((resolve, reject) => {
+      const channelId = vodRequest.playlistId;
+      if (this.assets[channelId]) {
+        const vod = this.assets[channelId][this.pos[channelId]++];
+        if (this.pos[channelId] > this.assets[channelId].length - 1) {
+          this.pos[channelId] = 0;
+        }
+        resolve({ id: vod.id, title: vod.title, uri: vod.uri });
+      } else {
+        reject("Invalid channelId provided");
+      }
+    });
+  }
+}
+
+class RefChannelManager implements IChannelManager {
+  private channels: Channel[];
+
+  constructor() {
+    this.channels = [
+      {
+        id: "1",
+        profile: this._getProfile(),
+        // Per-channel ad-break configuration. Overrides the engine-level
+        // `adBreak` default when present.
+        adBreak: {
+          // Master enable flag. When false (the default) no interstitial
+          // metadata is emitted and the manifest is unchanged.
+          enabled: true,
+          // Ad-serving endpoint queried to fill the break. Must be an
+          // absolute http(s) URL when enabled. It should answer with JSON
+          // shaped as { assetUri } | { assetList } | { assets: [...] }.
+          adServerUri: "https://ad-endpoint.example.com/vast",
+          // Slate shown while the break is being resolved, and used as the
+          // fallback if the ad-serving endpoint times out or errors.
+          slate: {
+            uri: "https://maitv-vod.lab.eyevinn.technology/slate-consuo.mp4/master.m3u8",
+            repetitions: 10,
+            duration: 4000,
+          },
+        },
+      },
+    ];
+  }
+
+  getChannels(): Channel[] {
+    return this.channels;
+  }
+
+  _getProfile(): ChannelProfile[] {
+    return [
+      { bw: 6134000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [1024, 458] },
+      { bw: 2323000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [640, 286] },
+      { bw: 1313000, codecs: "avc1.4d001f,mp4a.40.2", resolution: [480, 214] },
+    ];
+  }
+}
+
+const refAssetManager = new RefAssetManager();
+const refChannelManager = new RefChannelManager();
+
+const engineOptions: ChannelEngineOpts = {
+  heartbeat: "/",
+  averageSegmentDuration: 2000,
+  channelManager: refChannelManager,
+  defaultSlateUri:
+    "https://maitv-vod.lab.eyevinn.technology/slate-consuo.mp4/master.m3u8",
+  slateRepetitions: 10,
+  // Engine-level default applied to channels that do not carry their own
+  // `adBreak`. Left disabled here so only channel "1" opens ad breaks.
+  adBreak: { enabled: false },
+};
+
+const engine = new ChannelEngine(refAssetManager, engineOptions);
+engine.start();
+engine.listen(process.env.PORT || 8000);


### PR DESCRIPTION
## Summary
- Implements #371: document the HLS-interstitial ad-break feature now that its implementation sub-issues (#367 config surface, #368 EXT-X-DATERANGE emission, #369 slate coordination, #370 ad-endpoint resolution) have all landed on master.

## Changes
- `docs/reference.md`: new "Ad-break configuration (HLS interstitials)" section — field tables for `adBreak` (`enabled`, `adServerUri`, `slate.{uri,repetitions,duration}`) with types/defaults/validation, plus the ad-replacement flow.
- `README.md`: Features bullet, an "Ad breaks (HLS interstitials)" subsection linking to the reference, and the new example in the examples list.
- `examples/adbreak.ts`: minimal channel wired with a per-channel `adBreak` (enabled + `adServerUri` + `slate`) and an engine-level disabled default, matching `default.ts` style. Vendor-neutral throughout (uses `ad-endpoint.example.com`).

## Test plan
- PROOF: `npm run build && npm test` → 113 specs, 0 failures, 7 pending. New `examples/adbreak.ts` compiles under the repo tsconfig (part of the TS build).

Closes #371

🤖 Automated via Channel Engine Dev daily-backlog-pr skill