### PR TITLE
chore: migrate engine session modules to TypeScript

### DIFF
--- a/engine/event_stream.ts
+++ b/engine/event_stream.ts
@@ -1,11 +1,13 @@
 class EventStream {
-  constructor(session) {
+  private _session: any;
+
+  constructor(session: any) {
     this._session = session;
   }
 
-  poll() {
+  poll(): Promise<string> {
     return new Promise((resolve, reject) => {
-      let event = {};
+      let event: any = {};
       event = this._session.consumeEvent();
       if (event) {
         resolve(JSON.stringify(event));

--- a/engine/session.ts
+++ b/engine/session.ts
@@ -35,6 +35,8 @@ const AD_SERVER_TIMEOUT_MS = 2000;
 const timer = ms => new Promise(res => setTimeout(res, ms));
 
 class Session {
+  [key: string]: any;
+
   /**
    *
    * config: {
@@ -42,7 +44,7 @@ class Session {
    * }
    *
    */
-  constructor(assetManager, config, sessionStore) {
+  constructor(assetManager: any, config: any, sessionStore: any) {
     this._assetManager = assetManager;
     this._sessionId = crypto.randomBytes(20).toString('hex');
 
@@ -296,7 +298,7 @@ class Session {
           }
           // Apply external diff compensation if available.
           if (this.diffCompensation && this.diffCompensation > 0) {
-            const DIFF_COMPENSATION = (reqTickInterval * this.diffCompensationRate).toFixed(2) * 1000;
+            const DIFF_COMPENSATION = ((reqTickInterval * this.diffCompensationRate).toFixed(2) as any) * 1000;
             debug(`[${this._sessionId}]: Adding ${DIFF_COMPENSATION}msec to tickInterval to compensate for schedule diff (current=${this.diffCompensation}msec)`);
             tickInterval += (DIFF_COMPENSATION / 1000);
             this.diffCompensation -= DIFF_COMPENSATION;
@@ -371,7 +373,7 @@ class Session {
       playheadStateMap[PlayheadState.CRASHED] = 'crashed';
       playheadStateMap[PlayheadState.STOPPED] = 'stopped';
 
-      const status = {
+      const status: any = {
         sessionId: this._sessionId,
         playhead: {
           state: playheadStateMap[state],
@@ -441,7 +443,7 @@ class Session {
     let waitTimeMs = 2000;
     for (let i = segments[Object.keys(segments)[0]].length - 1; 0 < i; i--) {
       if (segments[Object.keys(segments)[0]][i].duration) {
-        waitTimeMs = parseInt(1000 * (segments[Object.keys(segments)[0]][i].duration / 3), 10);
+        waitTimeMs = parseInt((1000 * (segments[Object.keys(segments)[0]][i].duration / 3)) as any, 10);
         break;
       }
     }
@@ -453,7 +455,7 @@ class Session {
       for (let i = audioSegments[groupId][lang].length - 1; 0 < i; i--) {
         const segment = audioSegments[groupId][lang][i];
         if (segment.duration) {
-          waitTimeMsAudio = parseInt(1000 * (segment.duration / 3), 10);
+          waitTimeMsAudio = parseInt((1000 * (segment.duration / 3)) as any, 10);
           break;
         }
       }
@@ -752,7 +754,7 @@ class Session {
       }
       return null;
     }
-    let newSessionState = {};
+    let newSessionState: any = {};
     if (sessionState.state === SessionState.VOD_NEXT_INITIATING || sessionState.state === SessionState.VOD_RELOAD_INITIATING) {
       if (isLeader) {
         const isOldVod = this._isOldVod(playheadState.playheadRef, currentVod.getDuration());
@@ -1448,7 +1450,7 @@ class Session {
           }
         } else {
           // Handle edge case where Leader loaded next vod but Follower remained in state=VOD_PLAYING
-          if ((this.prevMediaSeqOffset.video !== null) & (sessionState.mediaSeq !== this.prevMediaSeqOffset.video)) {
+          if (((this.prevMediaSeqOffset.video !== null) as any) & ((sessionState.mediaSeq !== this.prevMediaSeqOffset.video) as any)) {
             debug(`[${this._sessionId}]: state=VOD_PLAYING, current[${sessionState.vodMediaSeqVideo}], prev[${this.prevVodMediaSeq.video}], total[${currentVod.getLiveMediaSequencesCount()}]`);
             debug(`[${this._sessionId}]: mediaSeq offsets -> current[${sessionState.vodMediaSeqVideo}], prev[${this.prevVodMediaSeq.video}]`);
             // Allow Follower to clear VodCache...
@@ -1911,7 +1913,7 @@ class Session {
   // the caller falls back to the slate-only break and the session tick is never
   // interrupted. Returns `null` immediately (no fetch) when the feature is
   // disabled or no `adServerUri` is configured.
-  async _resolveAdBreakAsset(fetchImpl) {
+  async _resolveAdBreakAsset(fetchImpl?: any) {
     if (!this.adBreak || !this.adBreak.enabled || !this.adBreak.adServerUri) {
       return null;
     }
@@ -2143,7 +2145,7 @@ class Session {
     });
   }
 
-  _loadSlate(afterVod, reps, unixTs) {
+  _loadSlate(afterVod: any, reps?: any, unixTs?: any) {
     return new Promise((resolve, reject) => {
       try {
         const slateVod = new HLSRepeatVod(this.slateUri, reps || this.slateRepetitions);
@@ -2214,10 +2216,10 @@ class Session {
     });
   }
 
-  _truncateVod(vodResponse) {
+  _truncateVod(vodResponse: any): Promise<any> {
     return new Promise((resolve, reject) => {
       try {
-        const options = {};
+        const options: any = {};
         if (vodResponse.startOffset) {
           options.offset = vodResponse.startOffset / 1000;
         }
@@ -2259,7 +2261,7 @@ class Session {
     });
   }
 
-  _truncateSlate(afterVod, requestedDuration, vodUri, unixTs) {
+  _truncateSlate(afterVod: any, requestedDuration: any, vodUri: any, unixTs?: any): Promise<any> {
     return new Promise((resolve, reject) => {
       let nexVodUri = null;
       try {
@@ -2376,7 +2378,7 @@ class Session {
     });
   }
 
-  _getFirstDuration(manifest) {
+  _getFirstDuration(manifest: any): Promise<any> {
     return new Promise((resolve, reject) => {
       try {
         const parser = m3u8.createStream();
@@ -2412,7 +2414,7 @@ class Session {
     return 0;
   }
 
-  async _getCurrentPlayheadPosition(overrideVodMediaSeqVideo) {
+  async _getCurrentPlayheadPosition(overrideVodMediaSeqVideo?: any) {
     // Caller can pass the in-progress local vodMediaSeqVideo to avoid the Redis
     // round-trip and the race where the leader has incremented its local value
     // but hasn't written it to Redis yet (incrementAsync writes happen later via
@@ -2449,7 +2451,7 @@ class Session {
     return playheadPositions[seqIdx];
   }
 
-  _getLastDuration(manifest) {
+  _getLastDuration(manifest: any): Promise<any> {
     return new Promise((resolve, reject) => {
       try {
         const parser = m3u8.createStream();

--- a/engine/session_live.ts
+++ b/engine/session_live.ts
@@ -8,8 +8,8 @@ const fetch = require("node-fetch");
 const { m3u8Header, roundToThreeDecimals } = require("./util.js");
 const { AbortController } = require("abort-controller");
 
-const timer = (ms) => new Promise((res) => setTimeout(res, ms));
-const daterangeAttribute = (key, attr) => {
+const timer = (ms: number) => new Promise((res) => setTimeout(res, ms));
+const daterangeAttribute = (key: string, attr: any) => {
   if (key === "planned-duration" || key === "duration") {
     return key.toUpperCase() + "=" + `${attr.toFixed(3)}`;
   } else {
@@ -33,13 +33,22 @@ const PlaylistTypes = Object.freeze({
   SUBTITLE: 3,
 });
 
+// Implicit globals assigned to (without a var/let/const declaration) inside
+// class methods; declared ambiently here so the type-checker knows the names.
+// `declare` emits no JavaScript, preserving the original runtime behavior
+// (undeclared assignment / cross-call global) exactly.
+declare let byteRangeOffset: any;
+declare let list: any;
+
 /**
  * When we implement subtitle support in live-mix we should place it in its own file/or share it with audio
  * we should also remove audio implementation when we implement subtitles from this file so we don't get at 4000 line long file.
  */
 
 class SessionLive {
-  constructor(config, sessionLiveStore) {
+  [key: string]: any;
+
+  constructor(config: any, sessionLiveStore: any) {
     this.sessionId = crypto.randomBytes(20).toString("hex");
     this.sessionLiveStateStore = sessionLiveStore.sessionLiveStateStore;
     this.instanceId = sessionLiveStore.instanceId;
@@ -624,7 +633,7 @@ class SessionLive {
   }
 
   async getCurrentMediaAndDiscSequenceCount() {
-    const counts = {
+    const counts: any = {
       mediaSeq: this.mediaSeqCountVideo,
       discSeq: this.discSeqCountVideo,
     };
@@ -747,7 +756,7 @@ class SessionLive {
       clearTimeout(timeout);
     }
 
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       parser.on("m3u", (m3u) => {
         debug(`[${this.sessionId}]: ...Fetched a New Live Master Manifest from:\n${masterManifestURI}`);
         let baseUrl = "";
@@ -928,7 +937,7 @@ class SessionLive {
             break;
           }
           const segDur = this._getAnyFirstSegmentDurationMs() || DEFAULT_PLAYHEAD_INTERVAL_MS;
-          const waitTimeMs = parseInt(segDur / 3, 10);
+          const waitTimeMs = parseInt((segDur / 3) as any, 10);
           debug(
             `[${this.sessionId}]: FOLLOWER: Leader has not put anything in store... Will check again in ${waitTimeMs}ms (Tries left=[${attempts}])`
           );
@@ -953,7 +962,7 @@ class SessionLive {
               break;
             }
             const segDur = this._getAnyFirstSegmentDurationMs() || DEFAULT_PLAYHEAD_INTERVAL_MS;
-            const waitTimeMs = parseInt(segDur / 3, 10);
+            const waitTimeMs = parseInt((segDur / 3) as any, 10);
             debug(
               `[${this.sessionId}]: FOLLOWER: Leader has not put anything audio in store... Will check again in ${waitTimeMs}ms (Tries left=[${attempts}])`
             );
@@ -999,7 +1008,7 @@ class SessionLive {
             );
           }
           const segDur = this._getAnyFirstSegmentDurationMs() || DEFAULT_PLAYHEAD_INTERVAL_MS;
-          const waitTimeMs = parseInt(segDur / 3, 10);
+          const waitTimeMs = parseInt((segDur / 3) as any, 10);
           debug(`[${this.sessionId}]: FOLLOWER: Cannot find anything NEW in store... Will check again in ${waitTimeMs}ms (Tries left=[${attempts}])`);
           await timer(waitTimeMs);
           this.timerCompensation = false;
@@ -1171,6 +1180,9 @@ class SessionLive {
           audiotracksToSkipOnRetry = [];
           debug(`[${this.sessionId}]: Live Mseq counts=[${allStoredMediaSeqCountsVideo}]`);
           // Figure out what variants's are behind.
+          // @ts-ignore -- pre-existing behavior: `HIGHEST_MEDIA_SEQUENCE_COUNT`
+          // is a module-level `const`; this assignment throws at runtime if ever
+          // reached. Preserved byte-for-byte (type-only migration, #374).
           HIGHEST_MEDIA_SEQUENCE_COUNT = Math.max(...allStoredMediaSeqCountsVideo);
           Object.keys(this.liveSourceM3Us).map((variantKey) => {
             if (this.liveSourceM3Us[variantKey].mediaSeq === HIGHEST_MEDIA_SEQUENCE_COUNT) {
@@ -1197,14 +1209,14 @@ class SessionLive {
             // Find Highest MSEQ
             let [ahead, behind] = Object.keys(this.liveSourceM3Us).map((v) => {
               const c = this.liveSourceM3Us[v].mediaSeq;
-              const a = [];
-              const b = [];
+              const a: any[] = [];
+              const b: any[] = [];
               if (c === HIGHEST_MEDIA_SEQUENCE_COUNT) {
                 a.push({ c, v });
               } else {
                 b.push({ c, v });
               }
-            });
+            }) as any;
             // Find lowest bitrate with that highest MSEQ
             const variantToPaste = ahead.reduce((min, item) => (item.v < min.v ? item : min), list[0]);
             // Reassign that bitrate onto the one's originally planned for retry
@@ -1896,8 +1908,8 @@ class SessionLive {
     return null;
   }
 
-  _parseMediaManifest(m3u, mediaManifestUri, liveTargetBandwidth, isFirstBW, isLeader) {
-    return new Promise(async (resolve, reject) => {
+  _parseMediaManifest(m3u: any, mediaManifestUri: any, liveTargetBandwidth: any, isFirstBW: any, isLeader: any) {
+    return new Promise<void>(async (resolve, reject) => {
       try {
         if (!this.liveSegQueue[liveTargetBandwidth]) {
           this.liveSegQueue[liveTargetBandwidth] = [];
@@ -1940,8 +1952,8 @@ class SessionLive {
     });
   }
 
-  _parseAudioManifest(m3u, audioPlaylistUri, liveTargetAudiotrack, isFirstAT, isLeader) {
-    return new Promise(async (resolve, reject) => {
+  _parseAudioManifest(m3u: any, audioPlaylistUri: any, liveTargetAudiotrack: any, isFirstAT: any, isLeader: any) {
+    return new Promise<void>(async (resolve, reject) => {
       try {
         if (!this.liveSegQueueAudio[liveTargetAudiotrack]) {
           this.liveSegQueueAudio[liveTargetAudiotrack] = [];
@@ -2018,7 +2030,7 @@ class SessionLive {
       let timelinePosition = 0;
 
       for (let i = startIdx; i < playlistItems.length; i++) {
-        let seg = {};
+        let seg: any = {};
         const playlistItem = playlistItems[i];
         let segmentUri;
         let byteRange = undefined;
@@ -2338,6 +2350,9 @@ class SessionLive {
     }
 
     if (!segAmounts.every((val, i, arr) => val === arr[0])) {
+      // @ts-ignore -- pre-existing behavior: `console` is called as a function
+      // here (not `console.log`), which throws at runtime if this path is hit.
+      // Preserved byte-for-byte (type-only migration, #374).
       console(`[${this.sessionId}]: Cannot Generate audio Manifest! <${this.instanceId}> Not yet collected ALL segments from Live Source...`);
       return null;
     }
@@ -2505,8 +2520,8 @@ class SessionLive {
   // To only use profiles that the channel will actually need.
   _filterLiveProfiles() {
     const profiles = this.sessionLiveProfile;
-    const toKeep = new Set();
-    let newItem = {};
+    const toKeep = new Set<any>();
+    let newItem: any = {};
     profiles.forEach((profile) => {
       let bwToKeep = this._getNearestBandwidth(profile.bw, Object.keys(this.mediaManifestURIs));
       toKeep.add(bwToKeep);
@@ -2517,11 +2532,11 @@ class SessionLive {
     this.mediaManifestURIs = newItem;
   }
   _filterLiveProfilesAudio() {
-    const tracks = this.sessionAudioTracks.map((trackItem) => {
+    const tracks = this.sessionAudioTracks.map((trackItem: any) => {
       return this._getTrackFromGroupAndLang(trackItem.groupId, trackItem.language);
     });
-    const toKeep = new Set();
-    let newItem = {};
+    const toKeep = new Set<any>();
+    let newItem: any = {};
     tracks.forEach((t) => {
       let atToKeep = this._findNearestAudiotrack(t, Object.keys(this.audioManifestURIs));
       toKeep.add(atToKeep);
@@ -2534,12 +2549,14 @@ class SessionLive {
 
   _filterLiveAudioTracks() {
     let audioTracks = this.sessionAudioTracks;
-    const toKeep = new Set();
+    const toKeep = new Set<any>();
 
-    let newItemsAudio = {};
-    audioTracks.forEach((audioTrack) => {
+    let newItemsAudio: any = {};
+    audioTracks.forEach((audioTrack: any) => {
       let groupAndLangToKeep = this._findAudioGroupsForLang(audioTrack.language, this.audioManifestURIs);
-      toKeep.add(...groupAndLangToKeep);
+      // Cast to a 1-tuple so the (behavior-preserving) spread type-checks against
+      // Set.add's single parameter; runtime is unchanged (extra elements ignored).
+      toKeep.add(...(groupAndLangToKeep as [any]));
     });
 
     toKeep.forEach((trackInfo) => {
@@ -2608,8 +2625,8 @@ class SessionLive {
     return false;
   }
 
-  _getGroupAndLangFromTrack(track) {
-    const GLItem = {
+  _getGroupAndLangFromTrack(track: any) {
+    const GLItem: any = {
       groupId: null,
       language: null,
     };
@@ -2623,11 +2640,13 @@ class SessionLive {
         return GLItem;
       }
     }
+    // @ts-ignore -- pre-existing behavior: `g`/`l` are block-scoped to the
+    // `if (match)` block above and are not in scope here. Preserved as-is.
     console.error(`Failed to extract GroupID and Language g=${g};l=${l}`);
     return GLItem;
   }
 
-  _getLangFromTrack(track) {
+  _getLangFromTrack(track: any) {
     const match = track.match(/g:(.*?);l:(.*)/);
     if (match) {
       const g = match[1];
@@ -2636,11 +2655,13 @@ class SessionLive {
         return l;
       }
     }
+    // @ts-ignore -- pre-existing behavior: `g`/`l` are block-scoped to the
+    // `if (match)` block above and are not in scope here. Preserved as-is.
     console.error(`Failed to extract Language g=${g};l=${l}`);
     return null;
   }
 
-  _getGroupFromTrack(track) {
+  _getGroupFromTrack(track: any) {
     const match = track.match(/g:(.*?);l:(.*)/);
     if (match) {
       const g = match[1];
@@ -2649,11 +2670,13 @@ class SessionLive {
         return g;
       }
     }
+    // @ts-ignore -- pre-existing behavior: `g`/`l` are block-scoped to the
+    // `if (match)` block above and are not in scope here. Preserved as-is.
     console.error(`Failed to extract Group ID g=${g};l=${l}`);
     return null;
   }
 
-  _getTrackFromGroupAndLang(g, l) {
+  _getTrackFromGroupAndLang(g: any, l: any) {
     return `g:${g};l:${l}`;
   }
 

--- a/engine/stream_switcher.ts
+++ b/engine/stream_switcher.ts
@@ -22,8 +22,16 @@ const StreamType = Object.freeze({
 const FAIL_TIMEOUT = 3000;
 const MAX_FAILS = 3;
 
+// Implicit global assigned to (without a var/let/const declaration) inside
+// _createCustomSimpleSegmentList; declared ambiently here so the type-checker
+// knows the name. `declare` emits no JavaScript, preserving the original
+// (undeclared-assignment) runtime behavior exactly.
+declare let byteRangeOffset: any;
+
 class StreamSwitcher {
-  constructor(config) {
+  [key: string]: any;
+
+  constructor(config?: any) {
     this.sessionId = crypto.randomBytes(20).toString("hex");
     this.useDemuxedAudio = false;
     this.cloudWatchLogging = false;
@@ -260,16 +268,16 @@ class StreamSwitcher {
   async _initSwitching(state, session, sessionLive, scheduleObj) {
     this.working = true;
     const RESET_DELAY = 5000;
-    let liveCounts = 0;
-    let liveSegments = null;
-    let currVodCounts = 0;
-    let currLiveCounts = 0;
-    let currVodSegments = null;
-    let eventSegments = null;
+    let liveCounts: any = 0;
+    let liveSegments: any = null;
+    let currVodCounts: any = 0;
+    let currLiveCounts: any = 0;
+    let currVodSegments: any = null;
+    let eventSegments: any = null;
 
-    let liveAudioSegments = null;
-    let currVodAudioSegments = null;
-    let eventAudioSegments = null;
+    let liveAudioSegments: any = null;
+    let currVodAudioSegments: any = null;
+    let eventAudioSegments: any = null;
 
 
     let liveUri = null;
@@ -572,7 +580,7 @@ class StreamSwitcher {
     const audioURIs = {};
     const audioM3UPlaylists = {};
     try {
-      const m3u = await this._fetchParseM3u8(uri);
+      const m3u: any = await this._fetchParseM3u8(uri);
       debug(`[${this.sessionId}]: ...Fetched a New Preroll Slate Master Manifest from:\n${uri}`);
       // Is the first URI an actual Multivariant manifest
       if (m3u.items.StreamItem.length > 0) {
@@ -644,7 +652,7 @@ class StreamSwitcher {
         const results = await Promise.allSettled(loadMediaPromises);
         const resultsAudio = await Promise.allSettled(loadAudioPromises);
         // Process...
-        results.forEach((item, idx) => {
+        results.forEach((item: any, idx) => {
           if (item.status === "fulfilled" && item.value) {
             const resultM3U = item.value;
             const bw = bandwidths[idx];
@@ -653,7 +661,7 @@ class StreamSwitcher {
         });
 
         if (resultsAudio) {
-          resultsAudio.forEach((item, idx) => {
+          resultsAudio.forEach((item: any, idx) => {
             const resultM3U = item.value;
             const indexes = this._getGroupAndLangIdxFromIdx(idx, audioURIs)
             if (!audioM3UPlaylists[indexes.groupId]) {
@@ -709,7 +717,7 @@ class StreamSwitcher {
     let segments = [];
     for (let k = 0; k < segmentList.length; k++) {
       try {
-        let seg = {};
+        let seg: any = {};
         const playlistItem = segmentList[k];
         let segmentUri;
         let byteRange = undefined;
@@ -832,9 +840,14 @@ class StreamSwitcher {
         answerFound = true
       } else {
         storedLength = langs.length;
+        // @ts-ignore -- pre-existing behavior: `startIdx` is `const`; this path
+        // throws at runtime if ever reached. Preserved byte-for-byte in the TS
+        // port (type-only migration, #374) rather than "fixed" here.
         startIdx++;
       }
     }
+    // @ts-ignore -- pre-existing behavior: `groupIds`/`langs` are block-scoped to
+    // the while body above and are not in scope here. Preserved as-is.
     return { groupId: groupIds[startIdx], lang: langs[idx - storedLength] }
   }
 


### PR DESCRIPTION
## Summary
- Implements #374: convert the core session modules (`session.js`, `session_live.js`, `stream_switcher.js`, `event_stream.js`) to TypeScript — type-only, preserving behavior and public interfaces. Depends on #373 (state-store migration, merged).

## Changes
- `git mv` .js→.ts for all four modules; `module.exports` shapes (`Session`/`SessionLive`/`StreamSwitcher`/`EventStream`) unchanged so specs and `server.ts` resolve identically via the existing `spec/helpers/ts-resolve.js` loader.
- Typed constructor/public-method params; `any` at dynamic interop boundaries (HLSVod/m3u8/node-fetch/debug). A per-class `[key: string]: any` index signature keeps the JS-style dynamic `this.field` assignment valid without altering runtime (index signatures emit nothing).
- No `extends` in these files, so no class-field-clobber (`declare`) hazard applied. Pre-existing latent JS bugs on never-exercised code paths preserved as-is under `@ts-ignore` (NOT fixed — avoids behavior change).

## Test plan
- PROOF: `npm run build` → tsc exit 0; `npm test` → 113 specs, 0 failures, 7 pending; `NODE_OPTIONS=--no-experimental-strip-types npm test` (CI Node 20 condition) → 113 specs, 0 failures. Unchanged from baseline.

Closes #374

🤖 Automated via Channel Engine Dev daily-backlog-pr skill