### PR TITLE
chore: add customVodRequestParams allowlist option on engine instance creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ a slate fallback if that endpoint cannot be reached. Configure it through the
 [docs/reference.md](docs/reference.md#ad-break-configuration-hls-interstitials)
 for the full field reference and `examples/adbreak.ts` for a runnable example.
 
+### Custom VOD request parameters
+
+The engine can be configured with an allowlist of query-parameter names that
+are permitted to be forwarded to the asset manager's `getNextVod()` request,
+through the `customVodRequestParams` option on `ChannelEngineOpts`. Only
+parameters named in the allowlist may be passed through; all others are
+ignored, and the default (option omitted) is an empty allowlist with no
+pass-through. See
+[docs/reference.md](docs/reference.md#custom-vod-request-parameters) for the
+field reference.
+
 ## System Requirements
 
 Supported Node.js Versions

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -80,3 +80,18 @@ When a break is opened on an enabled channel:
 
 See `examples/adbreak.ts` for a runnable channel wired with an ad break.
 
+## Custom VOD request parameters
+
+The engine can be configured with an allowlist of query-parameter names that are
+permitted to be forwarded to the asset manager's `getNextVod()` request. This is
+set through the `customVodRequestParams` option on `ChannelEngineOpts`. Only
+parameters whose name appears in the allowlist may be passed through; every other
+query parameter is ignored. When the option is omitted the allowlist is empty, so
+no parameters are forwarded (the default, current behaviour).
+
+### `ChannelEngineOpts` fields
+
+Field | Type | Default | Description
+----- | ---- | ------- | -----------
+customVodRequestParams (optional) | string[] | `[]` (empty — no pass-through) | Allowlist of query-parameter names permitted to be forwarded to `getNextVod()`. Config surface only for now; the forwarding itself is wired up in follow-up work.
+

--- a/engine/server.ts
+++ b/engine/server.ts
@@ -96,6 +96,13 @@ export interface ChannelEngineOpts {
   sessionHealthKey?: string;
   rollingPDT?: boolean;
   event?: boolean;
+  // Allowlist of query-parameter names permitted to be forwarded to the asset
+  // manager's getNextVod() request (issue #377). Only parameters whose name is
+  // present in this list may be passed through; all others are ignored. This
+  // issue only establishes the config surface — the actual pass-through is wired
+  // up in follow-ups (#378/#379/#380). Defaults to no allowlist (an empty list),
+  // i.e. no pass-through, when omitted.
+  customVodRequestParams?: string[];
   // Base stream-switch polling interval in milliseconds (default 3000).
   // This is the cadence at which the global StreamSwitchLoop calls
   // updateStreamSwitchAsync() to evaluate live-schedule switches.
@@ -272,6 +279,11 @@ export class ChannelEngine {
   private sessionResetKey: string = "";
   private sessionEventStream: boolean = false;
   private sessionHealthKey: string = "";
+  // Allowlist of query-parameter names permitted to be forwarded to
+  // getNextVod() (issue #377). Config surface only — defaults to an empty list
+  // (no pass-through) when the option is omitted. Consumed in follow-ups
+  // (#378/#379/#380).
+  private customVodRequestParams: string[] = [];
 
   // Validate and normalize an ad-break configuration (issue #367).
   // Returns a config that is always defined and disabled-by-default:
@@ -363,6 +375,13 @@ export class ChannelEngine {
     if (options && options.autoCreateSession !== undefined) {
       this.autoCreateSession = options.autoCreateSession;
     }
+    // Custom VOD request-parameter allowlist (issue #377). Config surface only —
+    // stored on the instance so follow-ups (#378/#379/#380) can consume it.
+    // Defaults to an empty list (no pass-through) when omitted.
+    this.customVodRequestParams =
+      options && Array.isArray(options.customVodRequestParams)
+        ? options.customVodRequestParams
+        : [];
     this.assetMgr = assetMgr;
     this.monitorTimer = {};
     this.server = fastify;

--- a/spec/engine/interface_spec.ts
+++ b/spec/engine/interface_spec.ts
@@ -53,7 +53,18 @@ describe("Asset Manager Interface", () => {
     const testAssetManager = new TestAssetManager({ errorHandler: errorHandler });
     const testChannelManager = new TestChannelManager();
 
-    const engine = new ChannelEngine(testAssetManager, { channelManager: testChannelManager });
+    // NOTE: the module-level fastify instance is a singleton, so only one
+    // *successful* ChannelEngine construction is possible per process (a second
+    // one throws FST_ERR_DUPLICATED_ROUTE). This is the suite's single such
+    // construction, so the custom-VOD-request-parameter allowlist (issue #377)
+    // is asserted here rather than in a separate construction. It is stored on
+    // the instance verbatim; config surface only — no forwarding to getNextVod()
+    // is wired up yet (#378/#379/#380).
+    const engine = new ChannelEngine(testAssetManager, {
+      channelManager: testChannelManager,
+      customVodRequestParams: ["category"]
+    });
+    expect(engine.customVodRequestParams).toEqual(["category"]);
     await engine.start();
     jasmine.clock().tick((10 * 1000) + 1);
   });


### PR DESCRIPTION
## Summary
- Implements #377: establishes the config surface for a query-parameter allowlist that downstream issues (#378/#379/#380) will consume to forward params into `getNextVod()`. **No forwarding behavior yet** — config surface only.

## Changes
- `engine/server.ts`: added optional `customVodRequestParams?: string[]` to `ChannelEngineOpts`; added a private `customVodRequestParams: string[]` field on `ChannelEngine`; stored it in the constructor, defaulting to `[]` (no pass-through) when omitted or not an array.
- `README.md` + `docs/reference.md`: documented the new option.
- `spec/engine/interface_spec.js`: extended the existing successful-construction spec to pass `customVodRequestParams: ["category"]` and assert it is stored on the instance.

## Test plan
PROOF (run on branch):
- `npm run build` → exit 0.
- `npm test` → `113 specs, 0 failures, 7 pending specs` (7 pending are pre-existing `xit`).

Scope note: downstream forwarding to `getNextVod()` is intentionally NOT implemented here — it is left for #378/#379/#380 per the issue's acceptance criteria.

Closes #377

🤖 Automated via Channel Engine Dev daily-backlog-pr skill