### PR TITLE
feat: extend VodRequest with custom pass-through params and forward them in getNextVod

### DIFF
--- a/engine/server.ts
+++ b/engine/server.ts
@@ -140,6 +140,12 @@ export interface VodRequest {
   sessionId: string;
   category?: string;
   playlistId: string;
+  // Optional custom pass-through parameters forwarded to the asset manager's
+  // getNextVod() (issue #378). Sourced from per-session state populated by the
+  // master-manifest request handler (wired up in #379) and filtered against the
+  // customVodRequestParams allowlist (#377). Optional and defaults to absent so
+  // existing IAssetManager implementations are unaffected.
+  customParams?: { [key: string]: string };
 }
 
 export interface VodResponseMetadata {

--- a/engine/session.ts
+++ b/engine/session.ts
@@ -107,6 +107,13 @@ class Session {
     // Ad-break / interstitial config surface (issue #367). Disabled by default;
     // no interstitial tags are emitted from this yet (follow-up #368).
     this.adBreak = { enabled: false };
+    // Custom pass-through parameters forwarded to the asset manager's
+    // getNextVod() (issue #378). Populated per-session by the master-manifest
+    // request handler (wired up in #379) after filtering against the
+    // customVodRequestParams allowlist (#377). Defaults to an empty object so
+    // that, until a setter populates it, existing IAssetManager implementations
+    // are unaffected.
+    this.customParams = {};
     if (config) {
       if (config.alwaysNewSegments) {
         this.alwaysNewSegments = config.alwaysNewSegments;
@@ -217,6 +224,14 @@ class Session {
 
   get sessionId() {
     return this._sessionId;
+  }
+
+  // Store the custom pass-through parameters for this session (issue #378).
+  // Intended to be called by the master-manifest request handler (#379) with the
+  // already-allowlist-filtered params. Passing a falsy value clears them back to
+  // an empty object so nothing extra is forwarded to the asset manager.
+  setCustomParams(customParams) {
+    this.customParams = customParams || {};
   }
 
   async startPlayheadAsync() {
@@ -2100,11 +2115,19 @@ class Session {
 
       let nextVodPromise;
 
-      nextVodPromise = this._assetManager.getNextVod({
+      // Forward per-session custom pass-through params (issue #378) when present.
+      // Only include the field if at least one param has been set, so existing
+      // IAssetManager implementations that don't expect it are unaffected.
+      const vodRequest: any = {
         sessionId: this._sessionId,
         category: this._category,
         playlistId: this._sessionId
-      });
+      };
+      if (this.customParams && Object.keys(this.customParams).length > 0) {
+        vodRequest.customParams = this.customParams;
+      }
+
+      nextVodPromise = this._assetManager.getNextVod(vodRequest);
 
       nextVodPromise.then(nextVod => {
         if (nextVod && nextVod.uri) {

--- a/spec/engine/session_spec.ts
+++ b/spec/engine/session_spec.ts
@@ -550,6 +550,53 @@ describe("Session", () => {
     });
   });
 
+  describe("custom pass-through params forwarding (issue #378)", () => {
+    it("defaults customParams to an empty object", () => {
+      const session = new Session("dummy", null, sessionLiveStore);
+      expect(session.customParams).toEqual({});
+    });
+
+    it("omits customParams from the getNextVod request when none are set", async () => {
+      let received;
+      const session = new Session(
+        {
+          getNextVod: async (vodRequest) => {
+            received = vodRequest;
+            return { id: "1", uri: "https://example.com/vod.m3u8" };
+          }
+        },
+        null,
+        sessionLiveStore
+      );
+      await session._getNextVod();
+      expect(received.customParams).toBeUndefined();
+    });
+
+    it("forwards custom params to the asset manager's getNextVod when set", async () => {
+      let received;
+      const session = new Session(
+        {
+          getNextVod: async (vodRequest) => {
+            received = vodRequest;
+            return { id: "1", uri: "https://example.com/vod.m3u8" };
+          }
+        },
+        null,
+        sessionLiveStore
+      );
+      session.setCustomParams({ foo: "bar", baz: "qux" });
+      await session._getNextVod();
+      expect(received.customParams).toEqual({ foo: "bar", baz: "qux" });
+    });
+
+    it("clears custom params back to an empty object when set with a falsy value", () => {
+      const session = new Session("dummy", null, sessionLiveStore);
+      session.setCustomParams({ foo: "bar" });
+      session.setCustomParams(undefined);
+      expect(session.customParams).toEqual({});
+    });
+  });
+
   describe("EXT-X-ENDLIST on served media playlists (event mode, issue #363)", () => {
     // A served media playlist ends its last line with a newline (segment lines are
     // "\n"-terminated by the vod lib), so ENDLIST is appended on its own line.


### PR DESCRIPTION
## Summary
- Implements #378: add an optional `customParams` field to `VodRequest` and forward per-session custom params through `_getNextVod()` into the asset manager's `getNextVod({...})`.

## Changes
- `engine/server.ts` — add optional `customParams?: { [key: string]: string }` to the `VodRequest` interface (backwards-compatible; field is optional).
- `engine/session.ts` — initialize per-session `customParams` to `{}`; add a minimal `setCustomParams()` setter (to be populated by the #379 request-handler plumbing); `_getNextVod()` attaches `customParams` only when at least one param is set, so existing asset managers are unaffected.
- `spec/engine/session_spec.ts` — 4 new specs: default-empty, field omitted when unset, forwarded when set, cleared on falsy setter.

## Scope
- The allowlist option this depends on (#377) is already merged to `master`.
- The `master.m3u8` query-param extraction in `_handleMasterManifest` is intentionally out of scope — that is #379, which depends on this PR.

## Test plan
- PROOF (`npm run build` then `npm test`): `117 specs, 0 failures, 7 pending specs` (baseline was 113; +4 new specs). `pretest` tsc typecheck passes.

Closes #378

🤖 Automated via Channel Engine Dev daily-backlog-pr skill