### PR TITLE
feat: plumb allowlisted master.m3u8 query params into session for getNextVod

### DIFF
--- a/engine/server.ts
+++ b/engine/server.ts
@@ -949,7 +949,22 @@ export class ChannelEngine {
     if (session) {
       const eventStream = new EventStream(session);
       eventStreams[session.sessionId] = eventStream;
-  
+
+      // Plumb allowlisted master.m3u8 query params into the session so the next
+      // _getNextVod() call includes them (#379). Sessions are persistent (created
+      // once in updateChannelsAsync and reused), so scope custom params per request:
+      // set them on every master-manifest request — using an empty object when the
+      // allowlist is unset or no allowlisted params are present — so a later request
+      // without them doesn't inherit a previous request's values. Non-allowlisted
+      // params are ignored.
+      const customParams: { [key: string]: string } = {};
+      for (const key of this.customVodRequestParams) {
+        if (request.query[key] !== undefined) {
+          customParams[key] = request.query[key];
+        }
+      }
+      session.setCustomParams(customParams);
+
       let filter;
       if (request.query['filter']) {
         debug(`Applying filter on master manifest ${request.query['filter']}`);


### PR DESCRIPTION
## Summary
- Implements #379: allowlisted `master.m3u8` query params now flow end-to-end into the asset manager's `getNextVod`.

## Changes
- `engine/server.ts` `_handleMasterManifest`: after the session is resolved, filter `request.query` down to keys in the engine's `customVodRequestParams` allowlist (#377) and call `session.setCustomParams(...)`.
- Per-request scoping: a fresh object is built and set on every master-manifest request (empty when the allowlist is unset/empty), so a later request without the params does not inherit an earlier request's values.
- Non-allowlisted params are never copied (ignored). When no allowlist is configured, the set is empty and `_getNextVod` (which already guards on non-empty `customParams`) forwards nothing — behavior unchanged.
- No `session.ts` change needed: `setCustomParams` and the `_getNextVod` copy into `VodRequest.customParams` (#378) already existed; this wires up the previously-uncalled setter.

## Test plan
- PROOF: `npm ci && npm run build && npm test` (jasmine) → `121 specs, 0 failures, 7 pending specs`
- Spec + README coverage for this option is scoped to #380 (follow-up), intentionally not included here.

Closes #379

🤖 Automated via Channel Engine Dev daily-backlog-pr skill