### PR TITLE
feat: reconcile audio presentation at source transitions across muxing modes

### DIFF
--- a/engine/stream_switcher.ts
+++ b/engine/stream_switcher.ts
@@ -448,6 +448,16 @@ class StreamSwitcher {
           eventSegments = await session.getTruncatedVodSegments(scheduleObj.uri, scheduleObj.duration / 1000);
           eventAudioSegments = await session.getTruncatedVodAudioSegments(scheduleObj.uri, scheduleObj.duration / 1000);
 
+          // #383: reconcile across a possible muxed<->demuxed boundary at this
+          // LIVE->VOD switch point. The channel OUTPUT mode is `useDemuxedAudio`;
+          // each side of the transition may or may not actually carry demuxed
+          // audio. We only ever write audio into the (demuxed-output) channel when
+          // the SPECIFIC source being written actually provided demuxed audio, so a
+          // muxed source crossing into a demuxed channel does not corrupt the audio
+          // group / audio discontinuity-sequence with empty or mismatched data.
+          const liveHasDemuxedAudioLTV =
+            this.useDemuxedAudio && liveAudioSegments && !this._isEmpty(liveAudioSegments.currMseqSegs);
+          const vodHasDemuxedAudioLTV = this.useDemuxedAudio && this._sourceHasDemuxedAudio(eventAudioSegments);
 
           if (!eventSegments) {
             debug(`[${this.sessionId}]: [ ERROR Switching from LIVE->VOD ]`);
@@ -458,7 +468,7 @@ class StreamSwitcher {
           }
 
           await session.setCurrentMediaAndDiscSequenceCount(liveCounts.mediaSeq - 1, liveCounts.discSeq - 1, liveCounts.audioSeq - 1, liveCounts.audioDiscSeq - 1);
-          if (this.useDemuxedAudio) {
+          if (liveHasDemuxedAudioLTV) {
             await session.setCurrentMediaSequenceSegments(liveSegments.currMseqSegs, liveSegments.segCount, false, liveAudioSegments.currMseqSegs, liveAudioSegments.segCount);
           } else {
             await session.setCurrentMediaSequenceSegments(liveSegments.currMseqSegs, liveSegments.segCount);
@@ -469,12 +479,16 @@ class StreamSwitcher {
             const prerollSegments = this.prerollsCache[this.sessionId].segments;
             eventSegments = this._mergeSegments(prerollSegments, eventSegments, true);
 
-            if (this.useDemuxedAudio) {
+            if (vodHasDemuxedAudioLTV) {
               const prerollAudioSegments = this.prerollsCache[this.sessionId].audioSegments;
               eventAudioSegments = this._mergeAudioSegments(prerollAudioSegments, eventAudioSegments, true);
             }
           }
-          await session.setCurrentMediaSequenceSegments(eventSegments, 0, true);
+          if (vodHasDemuxedAudioLTV) {
+            await session.setCurrentMediaSequenceSegments(eventSegments, 0, true, eventAudioSegments, 0);
+          } else {
+            await session.setCurrentMediaSequenceSegments(eventSegments, 0, true);
+          }
 
           await sessionLive.resetSession();
           sessionLive.resetLiveStoreAsync(RESET_DELAY); // In parallel
@@ -499,6 +513,14 @@ class StreamSwitcher {
           eventAudioSegments = await sessionLive.getCurrentAudioSequenceSegments();
           currLiveCounts = await sessionLive.getCurrentMediaAndDiscSequenceCount();
 
+          // #383: reconcile a possible muxed<->demuxed boundary across a LIVE->LIVE
+          // switch. Only carry the demuxed audio rendition when the outgoing live
+          // source actually produced one; if it didn't (a muxed source on a demuxed
+          // channel), skip the audio write so we don't push an empty audio group /
+          // desync the audio discontinuity-sequence into the next live source.
+          const liveHasDemuxedAudioLTL =
+            this.useDemuxedAudio && eventAudioSegments && !this._isEmpty(eventAudioSegments.currMseqSegs);
+
           await sessionLive.resetSession();
           await sessionLive.resetLiveStoreAsync(0);
 
@@ -508,10 +530,10 @@ class StreamSwitcher {
             this._insertTimedMetadata(prerollSegments, scheduleObj.timedMetadata || {});
             eventSegments.currMseqSegs = this._mergeSegments(prerollSegments, eventSegments.currMseqSegs, false);
 
-            if (this.useDemuxedAudio) {
+            if (liveHasDemuxedAudioLTL) {
               const prerollSegmentsAudio = this.prerollsCache[this.sessionId].audioSegments;
               this._insertTimedMetadataAudio(prerollSegmentsAudio, scheduleObj.timedMetadata || {});
-              eventSegments.currMseqSegs = this._mergeAudioSegments(prerollSegmentsAudio, eventAudioSegments.currMseqSegs, false);
+              eventAudioSegments.currMseqSegs = this._mergeAudioSegments(prerollSegmentsAudio, eventAudioSegments.currMseqSegs, false);
             }
           }
 
@@ -520,7 +542,9 @@ class StreamSwitcher {
             console.error("cound not set switch live-> live", currVodCounts.mediaSeq, currVodCounts.discSeq, currVodCounts.audioSeq, currVodCounts.audioDiscSeq)
           }
           await sessionLive.setCurrentMediaSequenceSegments(eventSegments.currMseqSegs);
-          await sessionLive.setCurrentAudioSequenceSegments(eventAudioSegments.currMseqSegs);
+          if (liveHasDemuxedAudioLTL) {
+            await sessionLive.setCurrentAudioSequenceSegments(eventAudioSegments.currMseqSegs);
+          }
           liveUri = await sessionLive.setLiveUri(scheduleObj.uri);
 
           if (!liveUri) {

--- a/spec/engine/stream_switcher_audio_reconcile_spec.ts
+++ b/spec/engine/stream_switcher_audio_reconcile_spec.ts
@@ -1,0 +1,158 @@
+const StreamSwitcher = require("../../engine/stream_switcher.js");
+
+// #383: reconcile audio presentation at source transitions when muxing modes
+// differ. Once #382 made muxing per-source, a demuxed-output channel can ingest
+// a source that lacks demuxed audio (a muxed source). At a transition that
+// crosses a muxed<->demuxed boundary the switcher must emit a single, consistent
+// output presentation: only carry the demuxed audio rendition into the write
+// when the SPECIFIC source being written actually provided demuxed audio, so the
+// audio group / audio discontinuity-sequence stay coherent across the switch.
+//
+// These specs drive `_initSwitching` directly (the same seam init_switching_spec
+// uses) with fully stubbed Session / SessionLive so the reconciliation DECISION
+// is exercised deterministically, without standing up live playlist fetching.
+
+const SwitcherState = Object.freeze({
+  V2L_TO_LIVE: 1,
+  V2L_TO_VOD: 2,
+  LIVE_TO_V2L: 3,
+  LIVE_TO_LIVE: 4,
+  LIVE_TO_VOD: 5,
+});
+
+// A demuxed video-segment map (bandwidth -> segment list).
+const mockVideoSegments = {
+  "180000": [
+    { duration: 7, uri: "http://mock/180000/seg09.ts" },
+    { duration: 7, uri: "http://mock/180000/seg10.ts" },
+    { discontinuity: true },
+  ],
+};
+// A demuxed audio-segment map (group -> lang -> segment list).
+const mockAudioSegments = {
+  aac: {
+    en: [
+      { duration: 7, uri: "http://mock/aac/en/seg09.aac" },
+      { duration: 7, uri: "http://mock/aac/en/seg10.aac" },
+      { discontinuity: true },
+    ],
+  },
+};
+
+// Build a Session double whose truncated-VOD source is either demuxed or muxed.
+function makeSessionDouble({ vodDemuxed }) {
+  return {
+    getCurrentMediaAndDiscSequenceCount: () =>
+      Promise.resolve({ mediaSeq: 5, discSeq: 1, audioSeq: 5, audioDiscSeq: 1 }),
+    getCurrentMediaSequenceSegments: () => Promise.resolve(mockVideoSegments),
+    getCurrentAudioSequenceSegments: () => Promise.resolve(mockAudioSegments),
+    getTruncatedVodSegments: () => Promise.resolve(JSON.parse(JSON.stringify(mockVideoSegments))),
+    // A muxed VOD returns {} from getTruncatedVodAudioSegments (see session.ts).
+    getTruncatedVodAudioSegments: () =>
+      Promise.resolve(vodDemuxed ? JSON.parse(JSON.stringify(mockAudioSegments)) : {}),
+    setCurrentMediaAndDiscSequenceCount: jasmine.createSpy("setCurrentMediaAndDiscSequenceCount").and.returnValue(Promise.resolve(true)),
+    setCurrentMediaSequenceSegments: jasmine.createSpy("setCurrentMediaSequenceSegments").and.returnValue(Promise.resolve(true)),
+  };
+}
+
+// Build a SessionLive double whose live source is either demuxed or muxed.
+function makeSessionLiveDouble({ liveDemuxed }) {
+  return {
+    getCurrentMediaSequenceSegments: () => Promise.resolve({ currMseqSegs: JSON.parse(JSON.stringify(mockVideoSegments)), segCount: 2 }),
+    // A muxed live source yields an empty currMseqSegs audio map.
+    getCurrentAudioSequenceSegments: () =>
+      Promise.resolve({ currMseqSegs: liveDemuxed ? JSON.parse(JSON.stringify(mockAudioSegments)) : {}, segCount: liveDemuxed ? 2 : 0 }),
+    getCurrentMediaAndDiscSequenceCount: () =>
+      Promise.resolve({ mediaSeq: 10, discSeq: 2, audioSeq: 10, audioDiscSeq: 2 }),
+    setCurrentMediaAndDiscSequenceCount: jasmine.createSpy("live.setCurrentMediaAndDiscSequenceCount").and.returnValue(Promise.resolve(true)),
+    setCurrentMediaSequenceSegments: jasmine.createSpy("live.setCurrentMediaSequenceSegments").and.returnValue(Promise.resolve(true)),
+    setCurrentAudioSequenceSegments: jasmine.createSpy("live.setCurrentAudioSequenceSegments").and.returnValue(Promise.resolve(true)),
+    resetSession: jasmine.createSpy("resetSession").and.returnValue(Promise.resolve(true)),
+    resetLiveStoreAsync: jasmine.createSpy("resetLiveStoreAsync").and.returnValue(Promise.resolve(true)),
+    setLiveUri: jasmine.createSpy("setLiveUri").and.returnValue(Promise.resolve("https://mock/live/master.m3u8")),
+  };
+}
+
+function demuxedSwitcher() {
+  const s = new StreamSwitcher({ streamSwitchManager: {}, useDemuxedAudio: true });
+  s.streamTypeLive = true;
+  s.prerollsCache = {};
+  return s;
+}
+
+describe("Audio presentation reconciliation across muxing-mode boundaries (#383)", () => {
+  const scheduleVod = {
+    eventId: "vod-x",
+    assetId: 1,
+    uri: "https://mock/vod/master.m3u8",
+    duration: 60 * 1000,
+  };
+  const scheduleLive = {
+    eventId: "live-y",
+    assetId: 2,
+    uri: "https://mock/live2/master.m3u8",
+  };
+
+  // --- LIVE -> VOD -------------------------------------------------------------
+
+  it("LIVE(demuxed)->VOD(muxed): does NOT push audio for the muxed VOD, but keeps the demuxed live audio", async () => {
+    const switcher = demuxedSwitcher();
+    const session = makeSessionDouble({ vodDemuxed: false });
+    const sessionLive = makeSessionLiveDouble({ liveDemuxed: true });
+
+    await switcher._initSwitching(SwitcherState.LIVE_TO_VOD, session, sessionLive, scheduleVod);
+
+    // Two writes happen: (1) the outgoing live segments, (2) the incoming VOD.
+    const calls = session.setCurrentMediaSequenceSegments.calls.allArgs();
+    expect(calls.length).toBe(2);
+    // (1) Outgoing demuxed live source -> audio carried (5 args, audio arg present).
+    expect(calls[0][3]).toBeDefined();
+    expect(calls[0][3]).toEqual(mockAudioSegments);
+    // (2) Incoming MUXED VOD -> NO audio arg (video-only reconcile).
+    expect(calls[1][3]).toBeUndefined();
+  });
+
+  it("LIVE(muxed)->VOD(demuxed): does NOT push audio for the muxed live, but DOES for the demuxed VOD", async () => {
+    const switcher = demuxedSwitcher();
+    const session = makeSessionDouble({ vodDemuxed: true });
+    const sessionLive = makeSessionLiveDouble({ liveDemuxed: false });
+
+    await switcher._initSwitching(SwitcherState.LIVE_TO_VOD, session, sessionLive, scheduleVod);
+
+    const calls = session.setCurrentMediaSequenceSegments.calls.allArgs();
+    expect(calls.length).toBe(2);
+    // (1) Outgoing MUXED live -> video-only write, no audio arg.
+    expect(calls[0][3]).toBeUndefined();
+    // (2) Incoming demuxed VOD -> audio carried.
+    expect(calls[1][3]).toBeDefined();
+    expect(calls[1][3]).toEqual(mockAudioSegments);
+  });
+
+  // --- LIVE -> LIVE ------------------------------------------------------------
+
+  it("LIVE(muxed)->LIVE(demuxed-channel): skips the empty audio write so the audio group stays coherent", async () => {
+    const switcher = demuxedSwitcher();
+    const session = makeSessionDouble({ vodDemuxed: true });
+    const sessionLive = makeSessionLiveDouble({ liveDemuxed: false });
+
+    const result = await switcher._initSwitching(SwitcherState.LIVE_TO_LIVE, session, sessionLive, scheduleLive);
+
+    expect(result).toBe(true);
+    // Video is always written.
+    expect(sessionLive.setCurrentMediaSequenceSegments).toHaveBeenCalled();
+    // The outgoing live source was muxed => no empty audio group is pushed.
+    expect(sessionLive.setCurrentAudioSequenceSegments).not.toHaveBeenCalled();
+  });
+
+  it("LIVE(demuxed)->LIVE(demuxed-channel): carries the audio rendition through the switch", async () => {
+    const switcher = demuxedSwitcher();
+    const session = makeSessionDouble({ vodDemuxed: true });
+    const sessionLive = makeSessionLiveDouble({ liveDemuxed: true });
+
+    const result = await switcher._initSwitching(SwitcherState.LIVE_TO_LIVE, session, sessionLive, scheduleLive);
+
+    expect(result).toBe(true);
+    expect(sessionLive.setCurrentMediaSequenceSegments).toHaveBeenCalled();
+    expect(sessionLive.setCurrentAudioSequenceSegments).toHaveBeenCalledWith(mockAudioSegments);
+  });
+});


### PR DESCRIPTION
## Summary
- Implements #383 (parent #271): reconcile audio presentation at the cross-mode transition seams that #382 deferred, so a demuxed-output channel stays consistent when a source's muxing mode differs across a switch.

## Reconciliation rule
Emit a single consistent output presentation for the whole channel: only write the demuxed audio rendition when the **specific source being written** actually provided demuxed audio (extending #382's `_sourceHasDemuxedAudio` / `!_isEmpty(currMseqSegs)` per-source signals). This keeps the audio group and audio discontinuity-sequence coherent when crossing a muxed↔demuxed boundary.

## Changes (`engine/stream_switcher.ts`, `_initSwitching`)
- **LIVE_TO_VOD**: derive `liveHasDemuxedAudioLTV` (outgoing live) and `vodHasDemuxedAudioLTV` (incoming VOD) independently; each write gates on its own side. The incoming VOD write previously dropped audio unconditionally (`setCurrentMediaSequenceSegments(eventSegments, 0, true)`) — now carries `eventAudioSegments` when the VOD is demuxed. Preroll audio merge gated per-source.
- **LIVE_TO_LIVE**: derive `liveHasDemuxedAudioLTL`; skip `setCurrentAudioSequenceSegments` and preroll audio merge when the outgoing live source is muxed. Also fixes a latent bug where merged preroll audio was written back onto the **video** field (`eventSegments.currMseqSegs`) instead of `eventAudioSegments.currMseqSegs`.
- V2L_TO_LIVE left as-is (V2L is the channel's own always-demuxed output).

## Tests
- `spec/engine/stream_switcher_audio_reconcile_spec.ts` (new): drives `_initSwitching` directly on a `useDemuxedAudio:true` switcher with stubbed Session/SessionLive, asserting — for both directions across LIVE→VOD and LIVE→LIVE — that a muxed source gets a video-only write while a demuxed source carries the audio rendition.

## Test plan
- PROOF: `npm ci && npm run build && npm test` (jasmine) → `128 specs, 0 failures, 7 pending specs`

Closes #383

🤖 Automated via Channel Engine Dev daily-backlog-pr skill